### PR TITLE
feat: split zarr/netcdf as optional dependency groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
           - xarray
           - matplotlib
           - lark
-          - hidefix
           - zarr
           - dask
           - deprecation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,17 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "dask[array]>=2025.2.0",
-    "h5netcdf>=1.6.1",
     "xarray>=2025.1.2",
     "numpy>=2.2.3",
-    "hidefix>=0.12.0",
     "lark>=1.2.2",
     "dictdiffer>=0.9.0",
     "deprecation>=2.1.0",
-    "zarr>=3.1.1",
 ]
+default-optional-dependency-keys = [
+    "netcdf",
+    "zarr",
+]
+
 license = "MIT"
 license-files = ["LICENSE.md"]
 authors = [
@@ -28,6 +30,14 @@ authors = [
 ]
 maintainers = [
     {name = "Owen Dowley", email = "owen.dowley@anu.edu.au"},
+]
+
+[project.optional-dependencies]
+netcdf = [
+    "netcdf4>=1.7.2",
+]
+zarr = [
+    "zarr>=3.1.1",
 ]
 
 [project.urls]
@@ -41,9 +51,8 @@ dev = [
     "pre-commit>=4.1.0",
     "ruff>=0.9.5",
     "pytest>=8.3.5",
-    "netcdf4>=1.7.2",
-    "sphinx>=7.2.0",
-    "sphinx-rtd-theme>=2.0.0",
+    "sphinx>=8.2.3",
+    "sphinx-rtd-theme>=3.0.2",
 ]
 
 [tool.pytest.ini_options]
@@ -87,5 +96,5 @@ extend-select = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["hidefix.*", "dictdiffer.*"]
+module = ["dictdiffer.*"]
 follow_untyped_imports = true

--- a/src/anu_ctlab_io/__init__.py
+++ b/src/anu_ctlab_io/__init__.py
@@ -4,6 +4,13 @@ from anu_ctlab_io._dataset import Dataset
 from anu_ctlab_io._datatype import DataType, StorageDType
 from anu_ctlab_io._version import version as __version__
 from anu_ctlab_io._voxel_properties import VoxelSize, VoxelUnit
+from contextlib import suppress
+
+with suppress(ImportError):
+    import anu_ctlab_io.netcdf as netcdf
+
+with suppress(ImportError):
+    import anu_ctlab_io.zarr as zarr
 
 __all__ = [
     "VoxelSize",

--- a/uv.lock
+++ b/uv.lock
@@ -19,17 +19,21 @@ dependencies = [
     { name = "dask", extra = ["array"] },
     { name = "deprecation" },
     { name = "dictdiffer" },
-    { name = "h5netcdf" },
-    { name = "hidefix" },
     { name = "lark" },
     { name = "numpy" },
     { name = "xarray" },
+]
+
+[package.optional-dependencies]
+netcdf = [
+    { name = "netcdf4" },
+]
+zarr = [
     { name = "zarr" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "netcdf4" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -42,17 +46,16 @@ requires-dist = [
     { name = "dask", extras = ["array"], specifier = ">=2025.2.0" },
     { name = "deprecation", specifier = ">=2.1.0" },
     { name = "dictdiffer", specifier = ">=0.9.0" },
-    { name = "h5netcdf", specifier = ">=1.6.1" },
-    { name = "hidefix", specifier = ">=0.12.0" },
     { name = "lark", specifier = ">=1.2.2" },
+    { name = "netcdf4", marker = "extra == 'netcdf'", specifier = ">=1.7.2" },
     { name = "numpy", specifier = ">=2.2.3" },
     { name = "xarray", specifier = ">=2025.1.2" },
-    { name = "zarr", specifier = ">=3.1.1" },
+    { name = "zarr", marker = "extra == 'zarr'", specifier = ">=3.1.1" },
 ]
+provides-extras = ["netcdf", "zarr"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "netcdf4", specifier = ">=1.7.2" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.9.5" },
@@ -313,56 +316,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/45/d8/8425e6ba5fcec61a1d16e41b1b71d2bf9344f1fe48012c2b48b9620feae5/fsspec-2025.3.2.tar.gz", hash = "sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6", size = 299281, upload-time = "2025-03-31T15:27:08.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/4b/e0cfc1a6f17e990f3e64b7d941ddc4acdc7b19d6edd51abf495f32b1a9e4/fsspec-2025.3.2-py3-none-any.whl", hash = "sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711", size = 194435, upload-time = "2025-03-31T15:27:07.028Z" },
-]
-
-[[package]]
-name = "h5netcdf"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h5py" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/6d/c1b8e48fccbb588c23033bf219a3190a50813857d78a4c1aae2e1f3969e9/h5netcdf-1.6.1.tar.gz", hash = "sha256:7ef4ecd811374d94d29ac5e7f7db71ff59b55ef8eeefbe4ccc2c316853d31894", size = 64456, upload-time = "2025-03-07T14:51:24.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/fc/e73747f3dd31906bfbb78c76069f67d91525fefa28492a1f949cbb4a3c7f/h5netcdf-1.6.1-py3-none-any.whl", hash = "sha256:1ec75cabd6ab50c6e7109d0c6595eb2960ba0e79fef2257607ab80838d84e6f6", size = 49561, upload-time = "2025-03-07T14:51:22.863Z" },
-]
-
-[[package]]
-name = "h5py"
-version = "3.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/2e/a22d6a8bfa6f8be33e7febd985680fba531562795f0a9077ed1eb047bfb0/h5py-3.13.0.tar.gz", hash = "sha256:1870e46518720023da85d0895a1960ff2ce398c5671eac3b1a41ec696b7105c3", size = 414876, upload-time = "2025-02-18T16:04:01.824Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/20/438f6366ba4ded80eadb38f8927f5e2cd6d2e087179552f20ae3dbcd5d5b/h5py-3.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:477c58307b6b9a2509c59c57811afb9f598aedede24a67da808262dfa0ee37b4", size = 3384442, upload-time = "2025-02-18T16:02:56.545Z" },
-    { url = "https://files.pythonhosted.org/packages/10/13/cc1cb7231399617d9951233eb12fddd396ff5d4f7f057ee5d2b1ca0ee7e7/h5py-3.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:57c4c74f627c616f02b7aec608a8c706fe08cb5b0ba7c08555a4eb1dde20805a", size = 2917567, upload-time = "2025-02-18T16:03:00.079Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d9/aed99e1c858dc698489f916eeb7c07513bc864885d28ab3689d572ba0ea0/h5py-3.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:357e6dc20b101a805ccfd0024731fbaf6e8718c18c09baf3b5e4e9d198d13fca", size = 4669544, upload-time = "2025-02-18T16:03:05.675Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/da/3c137006ff5f0433f0fb076b1ebe4a7bf7b5ee1e8811b5486af98b500dd5/h5py-3.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6f13f9b5ce549448c01e4dfe08ea8d1772e6078799af2c1c8d09e941230a90d", size = 4932139, upload-time = "2025-02-18T16:03:10.129Z" },
-    { url = "https://files.pythonhosted.org/packages/25/61/d897952629cae131c19d4c41b2521e7dd6382f2d7177c87615c2e6dced1a/h5py-3.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:21daf38171753899b5905f3d82c99b0b1ec2cbbe282a037cad431feb620e62ec", size = 2954179, upload-time = "2025-02-18T16:03:13.716Z" },
-    { url = "https://files.pythonhosted.org/packages/60/43/f276f27921919a9144074320ce4ca40882fc67b3cfee81c3f5c7df083e97/h5py-3.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e520ec76de00943dd017c8ea3f354fa1d2f542eac994811943a8faedf2a7d5cb", size = 3358040, upload-time = "2025-02-18T16:03:20.579Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/86/ad4a4cf781b08d4572be8bbdd8f108bb97b266a14835c640dc43dafc0729/h5py-3.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e79d8368cd9295045956bfb436656bea3f915beaa11d342e9f79f129f5178763", size = 2892766, upload-time = "2025-02-18T16:03:26.831Z" },
-    { url = "https://files.pythonhosted.org/packages/69/84/4c6367d6b58deaf0fa84999ec819e7578eee96cea6cbd613640d0625ed5e/h5py-3.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56dd172d862e850823c4af02dc4ddbc308f042b85472ffdaca67f1598dff4a57", size = 4664255, upload-time = "2025-02-18T16:03:31.903Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/41/bc2df86b72965775f6d621e0ee269a5f3ac23e8f870abf519de9c7d93b4d/h5py-3.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be949b46b7388074c5acae017fbbe3e5ba303fd9daaa52157fdfef30bbdacadd", size = 4927580, upload-time = "2025-02-18T16:03:36.429Z" },
-    { url = "https://files.pythonhosted.org/packages/97/34/165b87ea55184770a0c1fcdb7e017199974ad2e271451fd045cfe35f3add/h5py-3.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:4f97ecde7ac6513b21cd95efdfc38dc6d19f96f6ca6f2a30550e94e551458e0a", size = 2940890, upload-time = "2025-02-18T16:03:41.037Z" },
-]
-
-[[package]]
-name = "hidefix"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "netcdf4" },
-    { name = "numpy" },
-    { name = "xarray" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/c8/9c7a462f9e241604d551fc44cc1e4979896141a9cbe98e665300e4f4d93e/hidefix-0.12.0.tar.gz", hash = "sha256:a049519ee6650f8a656aee9a9af1f140dd15bdf85bd314e3fa1855c099c211c2", size = 9154583, upload-time = "2024-10-21T13:19:44.192Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/70/b10487781293d68a2f327d75d2a55542735e54de6841b84e183b573ccc14/hidefix-0.12.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6f1b17285e39b0c0de7fa982c13db1d4bcdbad656054f26e82201c9cf1bb530a", size = 1495442, upload-time = "2024-10-21T13:19:36.94Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4e/94105ea32c6767f3f3b76d2f9580bfe661796fa54cf8ccf2af50426588ca/hidefix-0.12.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:722fdaa57e9beabe6c8f601b5a52395c8896754086f63a9ef2ef7479b2f58092", size = 9335118, upload-time = "2024-10-21T13:19:38.881Z" },
-    { url = "https://files.pythonhosted.org/packages/37/32/b775b4e394dd5b62f35bd10483460e305e952fd085f2d62b419875c3dc00/hidefix-0.12.0-cp39-abi3-win_amd64.whl", hash = "sha256:71da4677141ed6120e2033c4a2790131ed4e07ef1e4e8c1ab981c14cd8ddce90", size = 3103853, upload-time = "2024-10-21T13:19:42.004Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- remove unused `hidefix` dependency
  - Consumers can still use this if they want via kwargs passed to `open_mfdataset`