### PR TITLE
ci: add caching to github lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: "0.6.3"
+      - name: pre-commit cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: run pre-commit checks
         run: |
-          uv run pre-commit run --all-files --show-diff-on-failure
+          uv run pre-commit run --all-files --show-diff-on-failure --color=always


### PR DESCRIPTION
Based on the caching of pre-commit [here](https://github.com/pre-commit/action/blob/main/action.yml).