### PR TITLE
docs: fix index "next" button

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,5 +3,5 @@
 .. toctree::
    :hidden:
 
-   introduction
+   self
    autoapi/index


### PR DESCRIPTION
Fixes this.

> Minor quirk: hitting next on the landing page (index.html) goes to introduction.html, which is identical.
https://github.com/MaterialsPhysicsANU/anu_ctlab_io/pull/38#pullrequestreview-3232526871