### PR TITLE
feat: add `compute` parameter to writers

### DIFF
--- a/src/anu_ctlab_io/_dataset.py
+++ b/src/anu_ctlab_io/_dataset.py
@@ -23,7 +23,9 @@ class AbstractDataset(ABC):
         pass
 
     @abstractmethod
-    def to_path(self, path: Path, *, filetype: str = "auto", compute: bool = True, **kwargs: Any) -> Delayed | None:
+    def to_path(
+        self, path: Path, *, filetype: str = "auto", compute: bool = True, **kwargs: Any
+    ) -> Delayed | None:
         pass
 
     @property
@@ -211,7 +213,9 @@ class Dataset(AbstractDataset):
         match filetype:
             case "NetCDF":
                 netcdf_mod = self._import_with_extra("anu_ctlab_io.netcdf", "netcdf")
-                return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
+                return netcdf_mod.dataset_to_netcdf(
+                    self, path, compute=compute, **kwargs
+                )
             case "zarr":
                 zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
                 return zarr_mod.dataset_to_zarr(self, path, compute=compute, **kwargs)
@@ -224,11 +228,15 @@ class Dataset(AbstractDataset):
                     netcdf_mod = self._import_with_extra(
                         "anu_ctlab_io.netcdf", "netcdf"
                     )
-                    return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
+                    return netcdf_mod.dataset_to_netcdf(
+                        self, path, compute=compute, **kwargs
+                    )
 
                 if path.name.endswith(".zarr"):
                     zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                    return zarr_mod.dataset_to_zarr(self, path, compute=compute, **kwargs)
+                    return zarr_mod.dataset_to_zarr(
+                        self, path, compute=compute, **kwargs
+                    )
 
                 if path.name.endswith(".raw"):
                     raw_mod = import_module("anu_ctlab_io.raw")
@@ -241,7 +249,9 @@ class Dataset(AbstractDataset):
                         netcdf_mod = self._import_with_extra(
                             "anu_ctlab_io.netcdf", "netcdf"
                         )
-                        return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
+                        return netcdf_mod.dataset_to_netcdf(
+                            self, path, compute=compute, **kwargs
+                        )
 
         raise ValueError(
             "Unable to determine output format from given `path`, perhaps specify `filetype`?",

--- a/src/anu_ctlab_io/_dataset.py
+++ b/src/anu_ctlab_io/_dataset.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from importlib import import_module
 from pathlib import Path
-from types import ModuleType
-from typing import Any, Self, cast
+from typing import Any, NoReturn, Self, cast
 
 import dask.array as da
 import numpy as np
@@ -78,6 +76,13 @@ class Dataset(AbstractDataset):
     _voxel_size: tuple[np.float32, np.float32, np.float32]
     _history: History
 
+    @staticmethod
+    def _raise_missing_extra(module: str, extra: str, cause: ImportError) -> NoReturn:
+        raise ImportError(
+            f"{module} is missing. Please install with the '{extra}' extra: "
+            f"pip install anu-ctlab-io[{extra}]"
+        ) from cause
+
     def __init__(
         self,
         data: da.Array,
@@ -111,15 +116,6 @@ class Dataset(AbstractDataset):
         self._history = history
         self._dataset_id = dataset_id
 
-    @staticmethod
-    def _import_with_extra(module: str, extra: str) -> ModuleType:
-        try:
-            return import_module(module)
-        except ImportError as e:
-            raise ImportError(
-                f"{module} is missing. Please install with the '{extra}' extra: pip install anu-ctlab-io[{extra}]"
-            ) from e
-
     @classmethod
     def from_path(
         cls,
@@ -140,29 +136,31 @@ class Dataset(AbstractDataset):
         if isinstance(path, str):
             path = Path(path)
 
+        def _from_netcdf() -> Dataset:
+            try:
+                from anu_ctlab_io.netcdf import dataset_from_netcdf
+            except ImportError as e:
+                cls._raise_missing_extra("anu_ctlab_io.netcdf", "netcdf", e)
+            return dataset_from_netcdf(path, parse_history=parse_history, **kwargs)
+
+        def _from_zarr() -> Dataset:
+            try:
+                from anu_ctlab_io.zarr import dataset_from_zarr
+            except ImportError as e:
+                cls._raise_missing_extra("anu_ctlab_io.zarr", "zarr", e)
+            return dataset_from_zarr(path, parse_history=parse_history, **kwargs)
+
         match filetype:
             case "NetCDF":
-                netcdf_mod = cls._import_with_extra("anu_ctlab_io.netcdf", "netcdf")
-                return netcdf_mod.dataset_from_netcdf(  # type: ignore[no-any-return]
-                    path, parse_history=parse_history, **kwargs
-                )
+                return _from_netcdf()
             case "zarr":
-                zarr_mod = cls._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                return zarr_mod.dataset_from_zarr(  # type: ignore[no-any-return]
-                    path, parse_history=parse_history, **kwargs
-                )
+                return _from_zarr()
             case "auto":
                 if path.name[-2:] == "nc":
-                    netcdf_mod = cls._import_with_extra("anu_ctlab_io.netcdf", "netcdf")
-                    return netcdf_mod.dataset_from_netcdf(  # type: ignore[no-any-return]
-                        path, parse_history=parse_history, **kwargs
-                    )
+                    return _from_netcdf()
 
                 if path.name[-4:] == "zarr":
-                    zarr_mod = cls._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                    return zarr_mod.dataset_from_zarr(  # type: ignore[no-any-return]
-                        path, parse_history=parse_history, **kwargs
-                    )
+                    return _from_zarr()
 
         raise (
             ValueError(
@@ -210,48 +208,48 @@ class Dataset(AbstractDataset):
         if "dataset_id" not in kwargs:
             kwargs["dataset_id"] = resolved_dataset_id
 
+        def _to_netcdf() -> Delayed | None:
+            try:
+                from anu_ctlab_io.netcdf import dataset_to_netcdf
+            except ImportError as e:
+                self._raise_missing_extra("anu_ctlab_io.netcdf", "netcdf", e)
+            return dataset_to_netcdf(self, path, compute=compute, **kwargs)
+
+        def _to_zarr() -> Delayed | None:
+            try:
+                from anu_ctlab_io.zarr import dataset_to_zarr
+            except ImportError as e:
+                self._raise_missing_extra("anu_ctlab_io.zarr", "zarr", e)
+            return dataset_to_zarr(self, path, compute=compute, **kwargs)
+
+        def _to_raw() -> Delayed | None:
+            from anu_ctlab_io.raw import dataset_to_raw
+
+            return dataset_to_raw(self, path, compute=compute, **kwargs)
+
         match filetype:
             case "NetCDF":
-                netcdf_mod = self._import_with_extra("anu_ctlab_io.netcdf", "netcdf")
-                return netcdf_mod.dataset_to_netcdf(
-                    self, path, compute=compute, **kwargs
-                )
+                return _to_netcdf()
             case "zarr":
-                zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                return zarr_mod.dataset_to_zarr(self, path, compute=compute, **kwargs)
+                return _to_zarr()
             case "raw":
-                raw_mod = import_module("anu_ctlab_io.raw")
-                return raw_mod.dataset_to_raw(self, path, compute=compute, **kwargs)  # type: ignore[no-any-return]
+                return _to_raw()
             case "auto":
                 # Check for explicit extensions
                 if path.name.endswith(".nc") or path.name.endswith("_nc"):
-                    netcdf_mod = self._import_with_extra(
-                        "anu_ctlab_io.netcdf", "netcdf"
-                    )
-                    return netcdf_mod.dataset_to_netcdf(
-                        self, path, compute=compute, **kwargs
-                    )
+                    return _to_netcdf()
 
                 if path.name.endswith(".zarr"):
-                    zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                    return zarr_mod.dataset_to_zarr(
-                        self, path, compute=compute, **kwargs
-                    )
+                    return _to_zarr()
 
                 if path.name.endswith(".raw"):
-                    raw_mod = import_module("anu_ctlab_io.raw")
-                    return raw_mod.dataset_to_raw(self, path, compute=compute, **kwargs)  # type: ignore[no-any-return]
+                    return _to_raw()
 
                 # Check if datatype is in filename (Mango convention)
                 if self._datatype is not None:
                     datatype_str = str(self._datatype)
                     if datatype_str in path.name:
-                        netcdf_mod = self._import_with_extra(
-                            "anu_ctlab_io.netcdf", "netcdf"
-                        )
-                        return netcdf_mod.dataset_to_netcdf(
-                            self, path, compute=compute, **kwargs
-                        )
+                        return _to_netcdf()
 
         raise ValueError(
             "Unable to determine output format from given `path`, perhaps specify `filetype`?",

--- a/src/anu_ctlab_io/_dataset.py
+++ b/src/anu_ctlab_io/_dataset.py
@@ -7,6 +7,7 @@ from typing import Any, Self, cast
 
 import dask.array as da
 import numpy as np
+from dask.delayed import Delayed
 
 from anu_ctlab_io._datatype import DataType, StorageDType
 from anu_ctlab_io._parse_history import History, HistoryValue
@@ -22,7 +23,7 @@ class AbstractDataset(ABC):
         pass
 
     @abstractmethod
-    def to_path(self, path: Path, *, filetype: str = "auto", **kwargs: Any) -> None:
+    def to_path(self, path: Path, *, filetype: str = "auto", compute: bool = True, **kwargs: Any) -> Delayed | None:
         pass
 
     @property
@@ -174,8 +175,9 @@ class Dataset(AbstractDataset):
         *,
         filetype: str = "auto",
         dataset_id: str | None = "auto",
+        compute: bool = True,
         **kwargs: Any,
-    ) -> None:
+    ) -> Delayed | None:
         """Writes the :any:`Dataset` to the given ``path``.
 
         The data will be written in one of the ANU mass data storage formats, and the optional extras required for the specific
@@ -189,6 +191,8 @@ class Dataset(AbstractDataset):
             - "auto" (default): Use self.dataset_id if available, otherwise generate new
             - str: Use this exact value
             - None: Generate new (legacy behavior)
+        :param compute: If ``True`` (default), compute immediately. If ``False``, return
+            a :any:`dask.delayed.Delayed` for deferred execution.
         :param kwargs: Additional keyword arguments passed to the format-specific writer.
         """
         if isinstance(path, str):
@@ -207,32 +211,28 @@ class Dataset(AbstractDataset):
         match filetype:
             case "NetCDF":
                 netcdf_mod = self._import_with_extra("anu_ctlab_io.netcdf", "netcdf")
-                netcdf_mod.dataset_to_netcdf(self, path, **kwargs)
-                return
+                return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
             case "zarr":
                 zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                zarr_mod.dataset_to_zarr(self, path, **kwargs)
-                return
+                return zarr_mod.dataset_to_zarr(self, path, compute=compute, **kwargs)
             case "raw":
                 raw_mod = import_module("anu_ctlab_io.raw")
-                return raw_mod.dataset_to_raw(self, path, **kwargs)  # type: ignore[no-any-return]
+                return raw_mod.dataset_to_raw(self, path, compute=compute, **kwargs)  # type: ignore[no-any-return]
             case "auto":
                 # Check for explicit extensions
                 if path.name.endswith(".nc") or path.name.endswith("_nc"):
                     netcdf_mod = self._import_with_extra(
                         "anu_ctlab_io.netcdf", "netcdf"
                     )
-                    netcdf_mod.dataset_to_netcdf(self, path, **kwargs)
-                    return
+                    return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
 
                 if path.name.endswith(".zarr"):
                     zarr_mod = self._import_with_extra("anu_ctlab_io.zarr", "zarr")
-                    zarr_mod.dataset_to_zarr(self, path, **kwargs)
-                    return
+                    return zarr_mod.dataset_to_zarr(self, path, compute=compute, **kwargs)
 
                 if path.name.endswith(".raw"):
                     raw_mod = import_module("anu_ctlab_io.raw")
-                    return raw_mod.dataset_to_raw(self, path, **kwargs)  # type: ignore[no-any-return]
+                    return raw_mod.dataset_to_raw(self, path, compute=compute, **kwargs)  # type: ignore[no-any-return]
 
                 # Check if datatype is in filename (Mango convention)
                 if self._datatype is not None:
@@ -241,8 +241,7 @@ class Dataset(AbstractDataset):
                         netcdf_mod = self._import_with_extra(
                             "anu_ctlab_io.netcdf", "netcdf"
                         )
-                        netcdf_mod.dataset_to_netcdf(self, path, **kwargs)
-                        return
+                        return netcdf_mod.dataset_to_netcdf(self, path, compute=compute, **kwargs)
 
         raise ValueError(
             "Unable to determine output format from given `path`, perhaps specify `filetype`?",

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -10,6 +10,7 @@ import dask
 import dask.array as da
 import h5netcdf.legacyapi as nc4  # type: ignore[import-not-found]
 import numpy as np
+from dask.delayed import Delayed
 
 from anu_ctlab_io._dataset import Dataset
 from anu_ctlab_io._datatype import DataType
@@ -24,8 +25,9 @@ def dataset_to_netcdf(
     max_file_size_mb: float | None = 500.0,
     compression_level: int = 0,
     history: History | None = None,
+    compute: bool = True,
     **extra_attrs: Any,
-) -> None:
+) -> Delayed | None:
     """Write a :any:`Dataset` to netcdf format.
 
     :param dataset: The :any:`Dataset` to write.
@@ -37,6 +39,8 @@ def dataset_to_netcdf(
     :param compression_level: NetCDF compression level (0-9). Default 0 (no compression).
     :param history: History entries to add. Keys are identifiers, values are strings
         or parsed history dicts. If None, uses dataset's history attribute.
+    :param compute: If ``True`` (default), compute immediately. If ``False``, return
+        a :any:`dask.delayed.Delayed` for deferred execution.
     :param extra_attrs: Additional global attributes to include.
     """
     if isinstance(path, str):
@@ -98,7 +102,7 @@ def dataset_to_netcdf(
         )
 
         if zdim > slices_per_file:
-            _write_split_netcdf(
+            return _write_split_netcdf(
                 data_array,
                 path,
                 datatype,
@@ -106,16 +110,17 @@ def dataset_to_netcdf(
                 common_attrs,
                 compression_level,
                 serialized_history,
+                compute,
             )
-            return
 
-    _write_single_netcdf(
+    return _write_single_netcdf(
         data_array,
         path,
         datatype,
         common_attrs,
         compression_level,
         serialized_history,
+        compute,
     )
 
 
@@ -197,14 +202,15 @@ def _write_single_netcdf(
     common_attrs: dict[str, Any],
     compression_level: int,
     serialized_history: dict[str, str] | None,
-) -> None:
+    compute: bool = True,
+) -> Delayed | None:
     """Write a single netcdf file."""
     if not str(path).endswith(".nc"):
         path = Path(str(path) + ".nc")
 
     zdim, _ydim, _xdim = data_array.shape
-    _write_block(
-        np.asarray(data_array),
+    task: Delayed = dask.delayed(_write_block)(  # type: ignore[attr-defined]
+        data_array,
         path,
         datatype,
         zdim,
@@ -216,6 +222,10 @@ def _write_single_netcdf(
         serialized_history,
         True,
     )
+    if compute:
+        task.compute()  # type: ignore[no-untyped-call]
+        return None
+    return task
 
 
 def _write_block(
@@ -260,7 +270,8 @@ def _write_split_netcdf(
     common_attrs: dict[str, Any],
     compression_level: int,
     serialized_history: dict[str, str] | None,
-) -> None:
+    compute: bool = True,
+) -> Delayed | None:
     """Write split netcdf files into a directory."""
     dir_path = _get_split_directory_path(base_path)
     dir_path.mkdir(parents=True, exist_ok=True)
@@ -294,7 +305,11 @@ def _write_split_netcdf(
             )
         )
 
-    dask.compute(*tasks)  # type: ignore[attr-defined,no-untyped-call]
+    task: Delayed = dask.delayed(lambda *_: None)(*tasks)  # type: ignore[attr-defined]
+    if compute:
+        task.compute()  # type: ignore[no-untyped-call]
+        return None
+    return task
 
 
 _NUMPY_TO_NETCDF_DTYPE_MAP = {

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -8,6 +8,7 @@ from typing import Any
 import dask.array as da
 import numpy as np
 import zarr
+from dask.delayed import Delayed
 from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.coordinate_transformations import VectorScale
 from ome_zarr_models.v05.multiscales import Dataset as OMEDataset
@@ -38,8 +39,9 @@ def dataset_to_zarr(
     chunks: tuple[int, ...] | None = None,
     shards: tuple[int, ...] | None = None,
     create_array_kwargs: dict[str, Any] | None = None,
+    compute: bool = True,
     **extra_attrs: Any,
-) -> None:
+) -> Delayed | None:
     """Write a :any:`Dataset` to Zarr format.
 
     :param dataset: The :any:`Dataset` to write.
@@ -64,6 +66,8 @@ def dataset_to_zarr(
         When provided, user is responsible for ensuring valid chunk/shard alignment.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
         For example, to set compression: ``create_array_kwargs={'compressors': [ZstdCodec(level=5)]}``.
+    :param compute: If ``True`` (default), compute immediately. If ``False``, return
+        a :any:`dask.delayed.Delayed` for deferred execution.
     :param extra_attrs: Additional attributes to include in mango metadata.
     """
     if isinstance(path, str):
@@ -123,7 +127,7 @@ def dataset_to_zarr(
         create_array_kwargs = {}
 
     if ome_zarr_version is not None:
-        _write_ome_zarr_group(
+        return _write_ome_zarr_group(
             data_array,
             path,
             dataset,
@@ -132,9 +136,10 @@ def dataset_to_zarr(
             create_array_kwargs,
             mango_attrs,
             ome_zarr_version,
+            compute,
         )
     else:
-        _write_zarr_array(
+        return _write_zarr_array(
             data_array,
             path,
             dataset,
@@ -142,6 +147,7 @@ def dataset_to_zarr(
             outer_shards,
             create_array_kwargs,
             mango_attrs,
+            compute,
         )
 
 
@@ -240,7 +246,8 @@ def _write_ome_zarr_group(
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
     ome_zarr_version: OMEZarrVersion,
-) -> None:
+    compute: bool = True,
+) -> Delayed | None:
     """Write data as an OME-Zarr group with Zarr v3 sharding.
 
     In Zarr v3 sharding:
@@ -314,7 +321,8 @@ def _write_ome_zarr_group(
     # that manifest as large regions of zeros in the output. Using da.store directly
     # bypasses that internal rechunk entirely, writing each dask chunk straight into
     # its corresponding region in the zarr array.
-    da.store(data_array, array, lock=False, compute=True)  # type: ignore[arg-type]
+    result: Delayed | None = da.store(data_array, array, lock=False, compute=compute)  # type: ignore[arg-type]
+    return result
 
 
 def _write_zarr_array(
@@ -325,7 +333,8 @@ def _write_zarr_array(
     outer_shards: tuple[int, ...],
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
-) -> None:
+    compute: bool = True,
+) -> Delayed | None:
     """Write data as a simple Zarr V3 array with mango metadata and sharding.
 
     In Zarr v3 sharding:
@@ -362,4 +371,5 @@ def _write_zarr_array(
     write_shape = array.shards or array.chunks
     data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
 
-    da.store(data_array, array, lock=False, compute=True)  # type: ignore[arg-type]
+    result: Delayed | None = da.store(data_array, array, lock=False, compute=compute)  # type: ignore[arg-type]
+    return result

--- a/tests/test_write_compute_false.py
+++ b/tests/test_write_compute_false.py
@@ -50,8 +50,12 @@ def test_zarr_compute_false_concurrent():
         path_lo = Path(tmpdir) / "lo.zarr"
         path_hi = Path(tmpdir) / "hi.zarr"
 
-        task_lo = anu_ctlab_io.zarr.dataset_to_zarr(lo, path_lo, dataset_id="lo", compute=False)
-        task_hi = anu_ctlab_io.zarr.dataset_to_zarr(hi, path_hi, dataset_id="hi", compute=False)
+        task_lo = anu_ctlab_io.zarr.dataset_to_zarr(
+            lo, path_lo, dataset_id="lo", compute=False
+        )
+        task_hi = anu_ctlab_io.zarr.dataset_to_zarr(
+            hi, path_hi, dataset_id="hi", compute=False
+        )
 
         assert task_lo is not None
         assert task_hi is not None
@@ -79,8 +83,12 @@ def test_netcdf_compute_false_concurrent():
         path_lo = Path(tmpdir) / "tomo_lo.nc"
         path_hi = Path(tmpdir) / "tomo_hi.nc"
 
-        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(lo, path_lo, dataset_id="lo", compute=False)
-        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(hi, path_hi, dataset_id="hi", compute=False)
+        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(
+            lo, path_lo, dataset_id="lo", compute=False
+        )
+        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(
+            hi, path_hi, dataset_id="hi", compute=False
+        )
 
         assert task_lo is not None
         assert task_hi is not None

--- a/tests/test_write_compute_false.py
+++ b/tests/test_write_compute_false.py
@@ -23,7 +23,6 @@ except ImportError:
     _HAS_ZARR = False
 
 import anu_ctlab_io
-import anu_ctlab_io.raw
 
 
 def _make_dataset(data: da.Array) -> anu_ctlab_io.Dataset:
@@ -50,12 +49,8 @@ def test_zarr_compute_false_concurrent():
         path_lo = Path(tmpdir) / "lo.zarr"
         path_hi = Path(tmpdir) / "hi.zarr"
 
-        task_lo = anu_ctlab_io.zarr.dataset_to_zarr(
-            lo, path_lo, dataset_id="lo", compute=False
-        )
-        task_hi = anu_ctlab_io.zarr.dataset_to_zarr(
-            hi, path_hi, dataset_id="hi", compute=False
-        )
+        task_lo = lo.to_path(path_lo, dataset_id="lo", compute=False)
+        task_hi = hi.to_path(path_hi, dataset_id="hi", compute=False)
 
         assert task_lo is not None
         assert task_hi is not None
@@ -83,12 +78,8 @@ def test_netcdf_compute_false_concurrent():
         path_lo = Path(tmpdir) / "tomo_lo.nc"
         path_hi = Path(tmpdir) / "tomo_hi.nc"
 
-        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(
-            lo, path_lo, dataset_id="lo", compute=False
-        )
-        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(
-            hi, path_hi, dataset_id="hi", compute=False
-        )
+        task_lo = lo.to_path(path_lo, dataset_id="lo", compute=False)
+        task_hi = hi.to_path(path_hi, dataset_id="hi", compute=False)
 
         assert task_lo is not None
         assert task_hi is not None
@@ -117,11 +108,17 @@ def test_netcdf_split_compute_false_concurrent():
         path_lo = Path(tmpdir) / "tomo_lo"
         path_hi = Path(tmpdir) / "tomo_hi"
 
-        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(
-            lo, path_lo, dataset_id="lo", max_file_size_mb=0.005, compute=False
+        task_lo = lo.to_path(
+            path_lo,
+            dataset_id="lo",
+            max_file_size_mb=0.005,
+            compute=False,
         )
-        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(
-            hi, path_hi, dataset_id="hi", max_file_size_mb=0.005, compute=False
+        task_hi = hi.to_path(
+            path_hi,
+            dataset_id="hi",
+            max_file_size_mb=0.005,
+            compute=False,
         )
 
         assert task_lo is not None
@@ -155,8 +152,8 @@ def test_raw_compute_false_concurrent():
         path_lo = Path(tmpdir) / "lo.raw"
         path_hi = Path(tmpdir) / "hi.raw"
 
-        task_lo = anu_ctlab_io.raw.dataset_to_raw(lo, path_lo, compute=False)
-        task_hi = anu_ctlab_io.raw.dataset_to_raw(hi, path_hi, compute=False)
+        task_lo = lo.to_path(path_lo, compute=False)
+        task_hi = hi.to_path(path_hi, compute=False)
 
         assert task_lo is not None
         assert task_hi is not None

--- a/tests/test_write_compute_false.py
+++ b/tests/test_write_compute_false.py
@@ -1,0 +1,163 @@
+"""Tests for writing with compute=False, demonstrating concurrent writes via dask.compute."""
+
+import tempfile
+from pathlib import Path
+
+import dask
+import dask.array as da
+import numpy as np
+import pytest
+
+try:
+    import anu_ctlab_io.netcdf
+
+    _HAS_NETCDF = True
+except ImportError:
+    _HAS_NETCDF = False
+
+try:
+    import anu_ctlab_io.zarr
+
+    _HAS_ZARR = True
+except ImportError:
+    _HAS_ZARR = False
+
+import anu_ctlab_io
+import anu_ctlab_io.raw
+
+
+def _make_dataset(data: da.Array) -> anu_ctlab_io.Dataset:
+    return anu_ctlab_io.Dataset(
+        data=data,
+        dimension_names=("z", "y", "x"),
+        voxel_unit=anu_ctlab_io.VoxelUnit.MM,
+        voxel_size=(0.05, 0.05, 0.05),
+        datatype=anu_ctlab_io.DataType.TOMO,
+    )
+
+
+@pytest.mark.skipif(not _HAS_ZARR, reason="Requires 'zarr' extra")
+def test_zarr_compute_false_concurrent():
+    """Split an array into two halves, write both concurrently with compute=False."""
+    shape = (20, 16, 16)
+    arr = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
+    data = da.from_array(arr, chunks=(10, 16, 16))
+
+    lo = _make_dataset(data[:10])
+    hi = _make_dataset(data[10:])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path_lo = Path(tmpdir) / "lo.zarr"
+        path_hi = Path(tmpdir) / "hi.zarr"
+
+        task_lo = anu_ctlab_io.zarr.dataset_to_zarr(lo, path_lo, dataset_id="lo", compute=False)
+        task_hi = anu_ctlab_io.zarr.dataset_to_zarr(hi, path_hi, dataset_id="hi", compute=False)
+
+        assert task_lo is not None
+        assert task_hi is not None
+
+        dask.compute(task_lo, task_hi)  # type: ignore[attr-defined]
+
+        read_lo = anu_ctlab_io.Dataset.from_path(path_lo)
+        read_hi = anu_ctlab_io.Dataset.from_path(path_hi)
+
+        assert np.array_equal(read_lo.data.compute(), arr[:10])
+        assert np.array_equal(read_hi.data.compute(), arr[10:])
+
+
+@pytest.mark.skipif(not _HAS_NETCDF, reason="Requires 'netcdf' extra")
+def test_netcdf_compute_false_concurrent():
+    """Split an array into two halves, write both concurrently with compute=False."""
+    shape = (20, 16, 16)
+    arr = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
+    data = da.from_array(arr, chunks=(10, 16, 16))
+
+    lo = _make_dataset(data[:10])
+    hi = _make_dataset(data[10:])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path_lo = Path(tmpdir) / "tomo_lo.nc"
+        path_hi = Path(tmpdir) / "tomo_hi.nc"
+
+        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(lo, path_lo, dataset_id="lo", compute=False)
+        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(hi, path_hi, dataset_id="hi", compute=False)
+
+        assert task_lo is not None
+        assert task_hi is not None
+
+        dask.compute(task_lo, task_hi)  # type: ignore[attr-defined]
+
+        read_lo = anu_ctlab_io.Dataset.from_path(path_lo, parse_history=False)
+        read_hi = anu_ctlab_io.Dataset.from_path(path_hi, parse_history=False)
+
+        assert np.array_equal(read_lo.data.compute(), arr[:10])
+        assert np.array_equal(read_hi.data.compute(), arr[10:])
+
+
+@pytest.mark.skipif(not _HAS_NETCDF, reason="Requires 'netcdf' extra")
+def test_netcdf_split_compute_false_concurrent():
+    """Split an array into two halves, write both as split NetCDF concurrently."""
+    shape = (40, 16, 16)
+    arr = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
+    data = da.from_array(arr, chunks=(10, 16, 16))
+
+    lo = _make_dataset(data[:20])
+    hi = _make_dataset(data[20:])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Each z-slice is 16*16*2 = 512 bytes; max_file_size_mb=0.005 => ~10 slices/file
+        path_lo = Path(tmpdir) / "tomo_lo"
+        path_hi = Path(tmpdir) / "tomo_hi"
+
+        task_lo = anu_ctlab_io.netcdf.dataset_to_netcdf(
+            lo, path_lo, dataset_id="lo", max_file_size_mb=0.005, compute=False
+        )
+        task_hi = anu_ctlab_io.netcdf.dataset_to_netcdf(
+            hi, path_hi, dataset_id="hi", max_file_size_mb=0.005, compute=False
+        )
+
+        assert task_lo is not None
+        assert task_hi is not None
+
+        dask.compute(task_lo, task_hi)  # type: ignore[attr-defined]
+
+        dir_lo = Path(str(path_lo) + "_nc")
+        dir_hi = Path(str(path_hi) + "_nc")
+
+        assert dir_lo.is_dir()
+        assert dir_hi.is_dir()
+
+        read_lo = anu_ctlab_io.Dataset.from_path(dir_lo, parse_history=False)
+        read_hi = anu_ctlab_io.Dataset.from_path(dir_hi, parse_history=False)
+
+        assert np.array_equal(read_lo.data.compute(), arr[:20])
+        assert np.array_equal(read_hi.data.compute(), arr[20:])
+
+
+def test_raw_compute_false_concurrent():
+    """Split an array into two halves, write both as raw binary concurrently."""
+    shape = (20, 16, 16)
+    arr = np.arange(np.prod(shape), dtype=np.uint16).reshape(shape)
+    data = da.from_array(arr, chunks=(10, 16, 16))
+
+    lo = _make_dataset(data[:10])
+    hi = _make_dataset(data[10:])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path_lo = Path(tmpdir) / "lo.raw"
+        path_hi = Path(tmpdir) / "hi.raw"
+
+        task_lo = anu_ctlab_io.raw.dataset_to_raw(lo, path_lo, compute=False)
+        task_hi = anu_ctlab_io.raw.dataset_to_raw(hi, path_hi, compute=False)
+
+        assert task_lo is not None
+        assert task_hi is not None
+
+        dask.compute(task_lo, task_hi)  # type: ignore[attr-defined]
+
+        half_shape = (10, 16, 16)
+        read_lo = np.frombuffer(path_lo.read_bytes(), dtype="<u2").reshape(half_shape)
+        read_hi = np.frombuffer(path_hi.read_bytes(), dtype="<u2").reshape(half_shape)
+
+        assert np.array_equal(read_lo, arr[:10])
+        assert np.array_equal(read_hi, arr[10:])

--- a/tests/test_write_compute_false.py
+++ b/tests/test_write_compute_false.py
@@ -104,20 +104,20 @@ def test_netcdf_split_compute_false_concurrent():
     hi = _make_dataset(data[20:])
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Each z-slice is 16*16*2 = 512 bytes; max_file_size_mb=0.005 => ~10 slices/file
+        # Each z-slice is 16*16 = 256 elements; elements_per_file=2560 => ~10 slices/file
         path_lo = Path(tmpdir) / "tomo_lo"
         path_hi = Path(tmpdir) / "tomo_hi"
 
         task_lo = lo.to_path(
             path_lo,
             dataset_id="lo",
-            max_file_size_mb=0.005,
+            elements_per_file=2560,
             compute=False,
         )
         task_hi = hi.to_path(
             path_hi,
             dataset_id="hi",
-            max_file_size_mb=0.005,
+            elements_per_file=2560,
             compute=False,
         )
 


### PR DESCRIPTION
This is a breaking change for type checkers only. Many methods can now return `Delayed | None` instead of just `None`. Default behaviour is unchanged.