### PR TITLE
feat: sanitise attributes for HDF5

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,9 @@
 [files]
 extend-exclude = ["tests/data/*"]
 
+[default]
+extend-ignore-re = ["(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"]
+
 [default.extend-words]
 # Don't correct "ome" to "some"
 ome = "ome"

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -132,6 +132,42 @@ def _create_dimensions(
     ncfile.createDimension(f"{datatype_str}_xdim", xdim)
 
 
+def _is_hdf5_compatible_dtype(dtype: np.dtype) -> bool:
+    """Check if a numpy dtype can be stored in HDF5."""
+    # HDF5 supports numeric types, bytes, and bool
+    return (
+        np.issubdtype(dtype, np.number)
+        or np.issubdtype(dtype, np.bytes_)
+        or dtype == np.bool_
+    )
+
+
+def _sanitise_attribute_value(value: Any) -> Any:
+    """Convert attribute value to an HDF5-compatible type.
+
+    Converts arrays and objects with incompatible dtypes to strings.
+    Strings are encoded as ASCII bytes to match reference NetCDF conventions.
+    """
+    match value:
+        # Numeric scalars are safe for HDF5
+        case int() | float() | np.integer() | np.floating():
+            return value
+        # Numpy arrays with HDF5-compatible dtype are safe
+        case np.ndarray() if _is_hdf5_compatible_dtype(value.dtype):
+            return value
+        # Convert list/tuple to array and recurse
+        case list() | tuple():
+            try:
+                arr = np.array(value)
+                return _sanitise_attribute_value(arr)
+            except (ValueError, TypeError):
+                pass
+
+    # Everything else: encode to string bytes
+    str_value = value if isinstance(value, str) else str(value)
+    return np.bytes_(str_value.encode("ascii"))
+
+
 def _set_global_attributes(
     ncfile: nc4.Dataset,
     zdim: int,
@@ -148,17 +184,13 @@ def _set_global_attributes(
     ncfile.setncattr("number_of_files", np.int32(num_files))
     ncfile.setncattr("zdim_range", np.array([z_start, z_end], dtype=np.int32))
     for key, value in common_attrs.items():  # NOTE: h5netcdf lacks setncatts
-        # h5netcdf stores Python str as UTF-8 NC_STRING; encode to bytes so it
-        # is stored as ASCII NC_CHAR, matching what the reference files use.
-        ncfile.setncattr(
-            key, np.bytes_(value.encode("ascii")) if isinstance(value, str) else value
-        )
+        ncfile.setncattr(key, _sanitise_attribute_value(value))
 
     if include_history and serialized_history:
         for key, value in serialized_history.items():
             ncfile.setncattr(
                 f"history_{key}",
-                np.bytes_(value.encode("ascii")) if isinstance(value, str) else value,
+                _sanitise_attribute_value(value),
             )
 
 

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -146,11 +146,12 @@ def _sanitise_attribute_value(value: Any) -> Any:
     """Convert attribute value to an HDF5-compatible type.
 
     Converts arrays and objects with incompatible dtypes to strings.
-    Strings are encoded as ASCII bytes to match reference NetCDF conventions.
+    Strings are encoded as ASCII bytes (with backslash-escape for non-ASCII) to
+    match reference NetCDF conventions.
     """
     match value:
-        # Numeric scalars are safe for HDF5
-        case int() | float() | np.integer() | np.floating():
+        # Numeric scalars, bytes, and booleans are safe for HDF5
+        case int() | float() | np.integer() | np.floating() | bytes() | np.bytes_():
             return value
         # Numpy arrays with HDF5-compatible dtype are safe
         case np.ndarray() if _is_hdf5_compatible_dtype(value.dtype):
@@ -164,8 +165,9 @@ def _sanitise_attribute_value(value: Any) -> Any:
                 pass
 
     # Everything else: encode to string bytes
+    # Use backslashreplace error handler for non-ASCII characters
     str_value = value if isinstance(value, str) else str(value)
-    return np.bytes_(str_value.encode("ascii"))
+    return np.bytes_(str_value.encode("ascii", errors="backslashreplace"))
 
 
 def _set_global_attributes(

--- a/tests/test_sanitise_attribute.py
+++ b/tests/test_sanitise_attribute.py
@@ -1,0 +1,99 @@
+"""Tests for _sanitise_attribute_value function."""
+
+import numpy as np
+import pytest
+
+try:
+    from anu_ctlab_io.netcdf._writer import _sanitise_attribute_value
+
+    _HAS_NETCDF = True
+except ImportError:
+    _HAS_NETCDF = False
+
+
+@pytest.mark.skipif(not _HAS_NETCDF, reason="Requires 'netcdf' extra")
+class TestSanitiseAttributeValue:
+    """Test attribute value sanitization for HDF5 compatibility."""
+
+    def test_numeric_scalars_passthrough(self):
+        """Numeric scalars should pass through unchanged."""
+        assert _sanitise_attribute_value(42) == 42
+        assert _sanitise_attribute_value(3.14) == 3.14
+        assert _sanitise_attribute_value(np.int32(10)) == np.int32(10)
+        assert _sanitise_attribute_value(np.float64(2.71)) == np.float64(2.71)
+
+    def test_bytes_passthrough(self):
+        """Bytes should pass through unchanged."""
+        byte_val = b"test"
+        result = _sanitise_attribute_value(byte_val)
+        assert result is byte_val
+
+    def test_np_bytes_passthrough(self):
+        """np.bytes_ should pass through unchanged."""
+        np_byte_val = np.bytes_(b"test")
+        result = _sanitise_attribute_value(np_byte_val)
+        assert result is np_byte_val
+
+    def test_numeric_arrays_passthrough(self):
+        """Numeric arrays should pass through unchanged."""
+        arr = np.array([1, 2, 3], dtype=np.int32)
+        result = _sanitise_attribute_value(arr)
+        assert result is arr
+
+    def test_object_dtype_array_to_string(self):
+        """Object dtype arrays should be converted to ASCII-encoded bytes."""
+        arr = np.array(["test"], dtype=object)
+        result = _sanitise_attribute_value(arr)
+        assert isinstance(result, np.bytes_)
+        # Should contain the string representation
+        assert b"test" in result
+
+    def test_list_to_numeric_array(self):
+        """Lists with numeric elements should be converted to numeric arrays."""
+        lst = [1, 2, 3]
+        result = _sanitise_attribute_value(lst)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype != np.object_
+        np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+    def test_tuple_to_numeric_array(self):
+        """Tuples with numeric elements should be converted to numeric arrays."""
+        tup = (1.0, 2.0, 3.0)
+        result = _sanitise_attribute_value(tup)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype != np.object_
+        np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0]))
+
+    def test_mixed_list_to_string(self):
+        """Lists with mixed types (resulting in object dtype) should be strings."""
+        lst = [1, "two", 3.0]
+        result = _sanitise_attribute_value(lst)
+        assert isinstance(result, np.bytes_)
+        assert b"1" in result and b"two" in result
+
+    def test_string_to_ascii_bytes(self):
+        """ASCII strings should be encoded to bytes."""
+        result = _sanitise_attribute_value("hello")
+        assert result == np.bytes_(b"hello")
+
+    def test_unicode_string_to_escaped_bytes(self):
+        """Non-ASCII Unicode should be backslash-escaped."""
+        result = _sanitise_attribute_value("café")
+        assert isinstance(result, np.bytes_)
+        # Should not raise UnicodeEncodeError
+        # The é should be escaped as \\xe9
+        assert b"caf\\xe9" in result  # spellchecker:disable-line
+
+    def test_datetime_to_string(self):
+        """Datetime values should be converted to strings."""
+        dt = np.datetime64("2026-04-20")
+        result = _sanitise_attribute_value(dt)
+        assert isinstance(result, np.bytes_)
+        assert b"2026" in result
+
+    def test_complex_to_string(self):
+        """Complex numbers should be converted to strings."""
+        val = complex(1, 2)
+        result = _sanitise_attribute_value(val)
+        assert isinstance(result, np.bytes_)
+        assert b"1" in result and b"2" in result


### PR DESCRIPTION
Addresses `TypeError: Object dtype dtype('O') has no native HDF5 equivalent` on `setncattr`, which I was hitting running the cylinder unwrapping CLI.