### PR TITLE
feat: change default zarr chunking

### DIFF
--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -1,12 +1,12 @@
 """Write data to the ANU CTLab zarr data format."""
 
+import warnings
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import dask.array as da
-import numpy as np
 import zarr
 from ome_zarr_models.v05.axes import Axis
 from ome_zarr_models.v05.coordinate_transformations import VectorScale
@@ -18,6 +18,15 @@ from anu_ctlab_io._datatype import DataType
 from anu_ctlab_io._parse_history import History
 
 __all__ = ["OMEZarrVersion", "dataset_to_zarr"]
+
+_DEFAULT_3D_ZARR_CHUNKS = (32, 32, 32)
+_DEFAULT_3D_ZARR_SHARDS = (32, 0, 0)
+_DEFAULT_2D_ZARR_CHUNKS = (1, 256, 256)
+_DEFAULT_2D_ZARR_SHARDS = (1, 1024, 1024)
+
+type ChunkShape = tuple[int, ...]
+type ChunkSpec = ChunkShape | Literal["auto"]
+type ShardSpec = ChunkShape | Literal["auto"] | None
 
 
 class OMEZarrVersion(Enum):
@@ -32,15 +41,22 @@ def dataset_to_zarr(
     datatype: DataType | str | None = None,
     dataset_id: str | None = None,
     ome_zarr_version: OMEZarrVersion | None = OMEZarrVersion.v05,
-    max_shard_size_mb: float = 1000.0,
+    max_shard_size_mb: float | None = None,
     history: History | None = None,
-    chunk_size_mb: float = 10.0,
-    chunks: tuple[int, ...] | None = None,
-    shards: tuple[int, ...] | None = None,
+    chunk_size_mb: float | None = None,
+    chunks: ChunkSpec = "auto",
+    shards: ShardSpec = "auto",
     create_array_kwargs: dict[str, Any] | None = None,
     **extra_attrs: Any,
 ) -> None:
     """Write a :any:`Dataset` to Zarr format.
+
+    By default, 3D data is written with ``(32, 32, 32)`` chunks and
+    ``(32, 0, 0)`` shard shapes, where ``0`` means span the array axis rounded up
+    to a chunk multiple. Single-slice data uses ``(1, 256, 256)`` chunks and
+    ``(1, 1024, 1024)`` shard shapes. Default chunks are clamped to the array
+    shape, and default shards are clamped to avoid exceeding the array size
+    needlessly while still remaining multiples of the chunk shape.
 
     :param dataset: The :any:`Dataset` to write.
     :param path: Path to write the Zarr store.
@@ -49,19 +65,25 @@ def dataset_to_zarr(
     :param ome_zarr_version: OME-Zarr specification version to use.
         Set to :any:`OMEZarrVersion.v05` (default) to write OME-Zarr V0.5 group format.
         Set to ``None`` to write a simple Zarr V3 array with mango metadata.
-    :param max_shard_size_mb: Maximum shard size in MB for Zarr v3 sharding. Default 1000 MB (1 GB).
-        Shards group multiple chunks into indexed files for better filesystem performance.
-        Mutually exclusive with ``chunks`` and ``shards`` parameters.
-    :param history: Dictionary of history entries to add. Keys should be identifiers,
-        values are history strings.
-    :param chunk_size_mb: Target chunk size in MB for automatic chunking. Default 10.0 MB.
-        Mutually exclusive with ``chunks`` and ``shards`` parameters.
+    :param max_shard_size_mb: Maximum shard size in MB for Zarr v3 sharding.
+        Deprecated and ignored.
+        Passing this emits a warning and leaves layout selection to ``chunks``/``shards``.
+    :param history: Dictionary of history entries to add.
+        Keys should be identifiers, values are history strings.
+    :param chunk_size_mb: Target chunk size in MB for automatic chunking.
+        Deprecated and ignored.
+        Passing this emits a warning and leaves layout selection to ``chunks``/``shards``.
     :param chunks: Explicit chunk shape as a tuple (e.g., ``(10, 512, 512)``).
-        Must be provided together with ``shards``. Cannot be used with ``chunk_size_mb`` or ``max_shard_size_mb``.
-        When provided, user is responsible for ensuring valid chunk/shard alignment.
+        Can be provided on its own to write a non-sharded Zarr array, or together with ``shards`` to use the sharding codec.
+        ``'auto'`` uses the default chunk layout described above.
+        To write without sharding, pass ``shards=None`` explicitly.
+        A value of ``0`` means "span this axis" - the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
     :param shards: Explicit shard shape as a tuple (e.g., ``(100, 512, 512)``).
-        Must be provided together with ``chunks``. Cannot be used with ``chunk_size_mb`` or ``max_shard_size_mb``.
-        When provided, user is responsible for ensuring valid chunk/shard alignment.
+        May be provided together with an explicit ``chunks`` tuple.
+        Providing an explicit shard shape without also providing an explicit chunk shape is an error, including when ``chunks='auto'``.
+        Use ``None`` to disable sharding, or ``'auto'`` to use the default shard layout described above.
+        A value of ``0`` means "span the full array axis".
+        When provided, the user is responsible for ensuring shard shapes are evenly divisible by chunk shapes.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
         For example, to set compression: ``create_array_kwargs={'compressors': [ZstdCodec(level=5)]}``.
     :param extra_attrs: Additional attributes to include in mango metadata.
@@ -83,35 +105,30 @@ def dataset_to_zarr(
         dataset_id = f"{timestamp}_{datatype}"
 
     data_array = dataset.data
-    storage_dtype = data_array.dtype
 
-    shape = data_array.shape
-
-    chunks_provided = chunks is not None
-    shards_provided = shards is not None
-    sizes_provided = (chunk_size_mb != 10.0) or (max_shard_size_mb != 1000.0)
-
-    if chunks_provided != shards_provided:
-        raise ValueError(
-            "chunks and shards must both be provided or both be None. "
-            f"Got chunks={'provided' if chunks_provided else 'None'}, "
-            f"shards={'provided' if shards_provided else 'None'}."
+    ignored_size_args = ", ".join(
+        name
+        for name, value in (
+            ("chunk_size_mb", chunk_size_mb),
+            ("max_shard_size_mb", max_shard_size_mb),
+        )
+        if value is not None
+    )
+    if ignored_size_args:
+        warnings.warn(
+            f"{ignored_size_args} is ignored when writing Zarr. Use chunks/shards or 'auto' instead.",
+            UserWarning,
+            stacklevel=2,
         )
 
-    if chunks_provided and sizes_provided:
-        raise ValueError(
-            "Cannot specify both chunks/shards and chunk_size_mb/max_shard_size_mb. "
-            "Use either shape-based parameters (chunks and shards) or "
-            "size-based parameters (chunk_size_mb and max_shard_size_mb), not both."
-        )
+    if isinstance(shards, tuple) and chunks == "auto":
+        raise ValueError("shards cannot be provided without explicit chunks")
 
-    if chunks is not None and shards is not None:
-        inner_chunks = chunks
-        outer_shards = shards
-    else:
-        inner_chunks, outer_shards = _calculate_chunks_and_shards(
-            shape, storage_dtype, chunk_size_mb, max_shard_size_mb
-        )
+    inner_chunks, outer_shards = _resolve_zarr_layout(
+        shape=data_array.shape,
+        chunks=chunks,
+        shards=shards,
+    )
 
     mango_attrs: dict[str, Any] | None = None
     if datatype is not None:
@@ -145,57 +162,120 @@ def dataset_to_zarr(
         )
 
 
-def _calculate_chunks_and_shards(
-    shape: tuple[int, ...],
-    dtype: np.dtype[Any],
-    chunk_size_mb: float,
-    max_shard_size_mb: float,
-) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Calculate inner chunks and outer shards for Zarr v3 sharding.
+def _round_up_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
 
-    In Zarr v3:
-    - inner_chunks (chunks param) = subdivisions within each shard file
-    - outer_shards (shards param) = how data is split into shard files
 
-    This algorithm:
-    - Keeps xy planes intact (critical for CT data access patterns)
-    - Makes outer shards multiples of inner chunks for alignment
+def _resolve_zarr_layout(
+    *,
+    shape: ChunkShape,
+    chunks: ChunkSpec,
+    shards: ShardSpec,
+) -> tuple[ChunkShape, ChunkShape | None]:
+    """Resolve the final Zarr chunk/shard layout from the supported writer inputs.
 
-    :param shape: Array shape (z, y, x).
-    :param dtype: Array data type.
-    :param chunk_size_mb: Target size for inner chunks in MB.
-    :param max_shard_size_mb: Maximum shard size in MB.
-    :return: Tuple of (inner_chunks, outer_shards).
+    The resolution order is:
+    - explicit ``chunks``/``shards`` shapes when provided
+    - ``'auto'`` sentinels, which use the library default layout of ``(32, 32, 32)``
+      subchunks with X/Y-spanning shards instead of zarr-python's automatic layout
+      or, for ``z == 1`` data, ``(1, 256, 256)``-style in-plane chunks constrained by the array shape
+
+    Explicit shapes also support ``0`` as a sentinel. In ``chunks``, ``0`` means span
+    the full array axis for unsharded writes, or the full shard axis when ``shards`` is
+    provided. In ``shards``, ``0`` means span the array axis, rounded up to a multiple
+    of the resolved chunk size so the sharding codec remains valid.
     """
-    zdim, ydim, xdim = shape
-    bytes_per_element = np.dtype(dtype).itemsize
-    bytes_per_slice = ydim * xdim * bytes_per_element
+    anu_chunks, anu_shards = _default_chunks_and_shards(shape)
 
-    # Calculate inner chunk size (subdivisions within shards)
-    inner_target_bytes = chunk_size_mb * 1024 * 1024
-    z_inner = max(1, int(inner_target_bytes / bytes_per_slice))
-    z_inner = min(z_inner, zdim)
+    if chunks == "auto":
+        chunks = anu_chunks
+    if shards == "auto":
+        shards = anu_shards
 
-    inner_chunks = (z_inner, ydim, xdim)
+    return _normalize_explicit_shapes(shape, chunks, shards)
 
-    # Calculate outer shard size (how data is split into files)
-    shard_target_bytes = max_shard_size_mb * 1024 * 1024
-    z_outer = max(1, int(shard_target_bytes / bytes_per_slice))
-    z_outer = min(z_outer, zdim)
 
-    # Ensure outer shards are at least as large as inner chunks
-    # and are a multiple of inner chunks for proper alignment
-    if z_outer < z_inner:
-        z_outer = z_inner
-    else:
-        # Make outer a multiple of inner
-        multiple = max(1, z_outer // z_inner)
-        z_outer = z_inner * multiple
-        z_outer = min(z_outer, zdim)
+def _normalize_explicit_shapes(
+    shape: ChunkShape,
+    chunks: ChunkShape,
+    shards: ChunkShape | None,
+) -> tuple[ChunkShape, ChunkShape | None]:
+    """Validate explicit layout shapes and expand any zero-valued span sentinels.
 
-    outer_shards = (z_outer, ydim, xdim)
+    A zero chunk size spans the corresponding shard axis when sharding is enabled,
+    otherwise it spans the full array axis. A zero shard size spans the array axis,
+    rounded up to a chunk multiple so zarr's sharding codec accepts the layout.
+    """
+    if len(chunks) != len(shape):
+        raise ValueError(
+            f"chunks must have the same number of dimensions as the array shape. Got chunks={chunks}, shape={shape}."
+        )
+    if shards is not None and len(shards) != len(shape):
+        raise ValueError(
+            f"shards must have the same number of dimensions as the array shape. Got shards={shards}, shape={shape}."
+        )
 
-    return inner_chunks, outer_shards
+    chunk_span = (
+        tuple(
+            axis_size if shard_size == 0 else shard_size
+            for shard_size, axis_size in zip(shards, shape, strict=True)
+        )
+        if shards is not None
+        else shape
+    )
+    resolved_chunks = tuple(
+        axis_size if chunk_size == 0 else chunk_size
+        for chunk_size, axis_size in zip(chunks, chunk_span, strict=True)
+    )
+
+    resolved_shards: ChunkShape | None = None
+    if shards is not None:
+        resolved_shards = tuple(
+            _round_up_to_multiple(axis_size, chunk_size)
+            if shard_size == 0
+            else shard_size
+            for shard_size, axis_size, chunk_size in zip(
+                shards, shape, resolved_chunks, strict=True
+            )
+        )
+
+    return resolved_chunks, resolved_shards
+
+
+def _default_chunks_and_shards(
+    shape: ChunkShape,
+) -> tuple[ChunkShape, ChunkShape]:
+    """Return the library default chunk and shard layout for a 3D CT volume.
+
+    Volumes use 32-cubed chunks by default, while single-slice data uses larger
+    in-plane chunks. Shards keep one chunk along z and span each in-plane axis,
+    rounded up to a chunk multiple for valid zarr sharding.
+    """
+    default_chunks, default_shards = (
+        (_DEFAULT_2D_ZARR_CHUNKS, _DEFAULT_2D_ZARR_SHARDS)
+        if shape[0] == 1
+        else (_DEFAULT_3D_ZARR_CHUNKS, _DEFAULT_3D_ZARR_SHARDS)
+    )
+    inner_chunks = tuple(
+        min(chunk_size, axis_size)
+        for chunk_size, axis_size in zip(default_chunks, shape, strict=True)
+    )
+    clamped_shards = tuple(
+        0
+        if shard_size == 0
+        else max(
+            chunk_size,
+            min(shard_size, _round_up_to_multiple(axis_size, chunk_size)),
+        )
+        for shard_size, axis_size, chunk_size in zip(
+            default_shards, shape, inner_chunks, strict=True
+        )
+    )
+    resolved_chunks, resolved_shards = _normalize_explicit_shapes(
+        shape, inner_chunks, clamped_shards
+    )
+    assert resolved_shards is not None
+    return resolved_chunks, resolved_shards
 
 
 def _build_mango_attrs(
@@ -235,8 +315,8 @@ def _write_ome_zarr_group(
     data_array: da.Array,
     path: Path,
     dataset: Dataset,
-    inner_chunks: tuple[int, ...],
-    outer_shards: tuple[int, ...],
+    inner_chunks: ChunkShape,
+    outer_shards: ChunkShape | None,
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
     ome_zarr_version: OMEZarrVersion,
@@ -246,6 +326,8 @@ def _write_ome_zarr_group(
     In Zarr v3 sharding:
     - inner_chunks (chunks param) = subdivisions within each shard file
     - outer_shards (shards param) = how data is split into shard files
+
+    If ``outer_shards`` is ``None``, the array is written without the sharding codec.
     """
 
     if not str(path).endswith(".zarr"):
@@ -321,14 +403,14 @@ def _write_zarr_array(
     data_array: da.Array,
     path: Path,
     dataset: Dataset,
-    inner_chunks: tuple[int, ...],
-    outer_shards: tuple[int, ...],
+    inner_chunks: ChunkShape,
+    outer_shards: ChunkShape | None,
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
 ) -> None:
-    """Write data as a simple Zarr V3 array with mango metadata and sharding.
+    """Write data as a simple Zarr V3 array with mango metadata.
 
-    In Zarr v3 sharding:
+    When ``outer_shards`` is provided, Zarr v3 sharding is used:
     - inner_chunks (chunks param) = subdivisions within each shard file
     - outer_shards (shards param) = how data is split into shard files
     """
@@ -346,8 +428,8 @@ def _write_zarr_array(
     array = zarr.create_array(
         path,
         shape=data_array.shape,
-        chunks=inner_chunks,  # Inner chunk subdivisions
-        shards=outer_shards,  # Outer shard size
+        chunks=inner_chunks,
+        shards=outer_shards,
         dtype=data_array.dtype,
         dimension_names=list(dimension_names),
         overwrite=True,

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -115,8 +115,9 @@ def dataset_to_zarr(
         if value is not None
     )
     if ignored_size_args:
+        verb = "are" if "," in ignored_size_args else "is"
         warnings.warn(
-            f"{ignored_size_args} is ignored when writing Zarr. Use chunks/shards or 'auto' instead.",
+            f"{ignored_size_args} {verb} ignored when writing Zarr. Use chunks/shards or 'auto' instead.",
             UserWarning,
             stacklevel=2,
         )
@@ -163,6 +164,11 @@ def dataset_to_zarr(
 
 
 def _round_up_to_multiple(value: int, multiple: int) -> int:
+    if multiple == 0:
+        raise ValueError(
+            f"Cannot round up to a multiple of zero (value={value}). "
+            "The array likely has a zero-length axis, which is not supported."
+        )
     return ((value + multiple - 1) // multiple) * multiple
 
 
@@ -321,7 +327,7 @@ def _write_ome_zarr_group(
     mango_attrs: dict[str, Any] | None,
     ome_zarr_version: OMEZarrVersion,
 ) -> None:
-    """Write data as an OME-Zarr group with Zarr v3 sharding.
+    """Write data as an OME-Zarr group, optionally using Zarr v3 sharding.
 
     In Zarr v3 sharding:
     - inner_chunks (chunks param) = subdivisions within each shard file

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -68,18 +68,18 @@ def dataset_to_zarr(
     :param chunk_size_mb: Target chunk size in MB for automatic chunking.
         Deprecated and ignored.
         Passing this emits a warning and leaves layout selection to ``chunks``/``shards``.
-    :param chunks: Explicit chunk shape as a tuple (e.g., ``(10, 512, 512)``).
+    :param chunks: Explicit chunk shape as a tuple shape (e.g., ``(10, 512, 512)``), int (target # of elements), or ``'auto'``.
         Can be provided on its own to write a non-sharded Zarr array, or together with ``shards`` to use the sharding codec.
         An integer specifies the target number of elements for an automatically derived layout.
-        ``'auto'`` uses the default target of ``32**3`` elements.
+        ``'auto'`` uses a default target corresponding to ``32**3`` or ``256**2`` elements.
         To write without sharding, pass ``shards=None`` explicitly.
-        A value of ``0`` means "span this axis" - the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
-    :param shards: Explicit shard shape as a tuple (e.g., ``(100, 512, 512)``).
+        A value of ``0`` in a shape tuple  means "span this axis" - the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
+    :param shards: Explicit shard shape as a tuple shape (e.g., ``(100, 512, 512)``), int (target # of elements), or ``'auto'``.
         May be provided together with an explicit ``chunks`` tuple.
         Providing an explicit shard shape with ``chunks='auto'`` is an error.
         An integer specifies the target number of elements for an automatically derived layout.
-        Use ``None`` to disable sharding, or ``'auto'`` to use the default target of ``512**3`` elements.
-        A value of ``0`` means "span the full array axis".
+        Use ``None`` to disable sharding, or ``'auto'`` to use the default target of ``512**3`` or ``8192**2`` elements.
+        A value of ``0`` in a shape tuple means "span the full array axis".
         When provided, the user is responsible for ensuring shard shapes are evenly divisible by chunk shapes.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
         For example, to set compression: ``create_array_kwargs={'compressors': [ZstdCodec(level=5)]}``.

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -19,14 +19,12 @@ from anu_ctlab_io._parse_history import History
 
 __all__ = ["OMEZarrVersion", "dataset_to_zarr"]
 
-_DEFAULT_3D_ZARR_CHUNKS = (32, 32, 32)
-_DEFAULT_3D_ZARR_SHARDS = (32, 0, 0)
-_DEFAULT_2D_ZARR_CHUNKS = (1, 256, 256)
-_DEFAULT_2D_ZARR_SHARDS = (1, 1024, 1024)
+_DEFAULT_CHUNK_ELEMENTS = max(256**2, 32**3)
+_DEFAULT_SHARD_ELEMENTS = max(8192**2, 512**3)
 
 type ChunkShape = tuple[int, ...]
-type ChunkSpec = ChunkShape | Literal["auto"]
-type ShardSpec = ChunkShape | Literal["auto"] | None
+type ChunkSpec = ChunkShape | int | Literal["auto"]
+type ShardSpec = ChunkShape | int | Literal["auto"] | None
 
 
 class OMEZarrVersion(Enum):
@@ -51,12 +49,9 @@ def dataset_to_zarr(
 ) -> None:
     """Write a :any:`Dataset` to Zarr format.
 
-    By default, 3D data is written with ``(32, 32, 32)`` chunks and
-    ``(32, 0, 0)`` shard shapes, where ``0`` means span the array axis rounded up
-    to a chunk multiple. Single-slice data uses ``(1, 256, 256)`` chunks and
-    ``(1, 1024, 1024)`` shard shapes. Default chunks are clamped to the array
-    shape, and default shards are clamped to avoid exceeding the array size
-    needlessly while still remaining multiples of the chunk shape.
+    By default, chunks and shards use power-of-two square or cubic shapes targeting
+    ``32**3`` and ``512**3`` elements respectively. Shapes are trimmed to the array
+    dimensions, and shards are rounded up to chunk multiples.
 
     :param dataset: The :any:`Dataset` to write.
     :param path: Path to write the Zarr store.
@@ -75,13 +70,15 @@ def dataset_to_zarr(
         Passing this emits a warning and leaves layout selection to ``chunks``/``shards``.
     :param chunks: Explicit chunk shape as a tuple (e.g., ``(10, 512, 512)``).
         Can be provided on its own to write a non-sharded Zarr array, or together with ``shards`` to use the sharding codec.
-        ``'auto'`` uses the default chunk layout described above.
+        An integer specifies the target number of elements for an automatically derived layout.
+        ``'auto'`` uses the default target of ``32**3`` elements.
         To write without sharding, pass ``shards=None`` explicitly.
         A value of ``0`` means "span this axis" - the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
     :param shards: Explicit shard shape as a tuple (e.g., ``(100, 512, 512)``).
         May be provided together with an explicit ``chunks`` tuple.
-        Providing an explicit shard shape without also providing an explicit chunk shape is an error, including when ``chunks='auto'``.
-        Use ``None`` to disable sharding, or ``'auto'`` to use the default shard layout described above.
+        Providing an explicit shard shape with ``chunks='auto'`` is an error.
+        An integer specifies the target number of elements for an automatically derived layout.
+        Use ``None`` to disable sharding, or ``'auto'`` to use the default target of ``512**3`` elements.
         A value of ``0`` means "span the full array axis".
         When provided, the user is responsible for ensuring shard shapes are evenly divisible by chunk shapes.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
@@ -182,21 +179,22 @@ def _resolve_zarr_layout(
 
     The resolution order is:
     - explicit ``chunks``/``shards`` shapes when provided
-    - ``'auto'`` sentinels, which use the library default layout of ``(32, 32, 32)``
-      subchunks with X/Y-spanning shards instead of zarr-python's automatic layout
-      or, for ``z == 1`` data, ``(1, 256, 256)``-style in-plane chunks constrained by the array shape
+    - integer element targets and ``'auto'`` sentinels, which derive power-of-two
+      square or cubic layouts
 
     Explicit shapes also support ``0`` as a sentinel. In ``chunks``, ``0`` means span
     the full array axis for unsharded writes, or the full shard axis when ``shards`` is
     provided. In ``shards``, ``0`` means span the array axis, rounded up to a multiple
     of the resolved chunk size so the sharding codec remains valid.
     """
-    anu_chunks, anu_shards = _default_chunks_and_shards(shape)
-
     if chunks == "auto":
-        chunks = anu_chunks
+        chunks = _DEFAULT_CHUNK_ELEMENTS
+    if isinstance(chunks, int):
+        chunks = _auto_shape(shape, chunks)
     if shards == "auto":
-        shards = anu_shards
+        shards = _DEFAULT_SHARD_ELEMENTS
+    if isinstance(shards, int):
+        shards = _auto_shards(shape, chunks, shards)
 
     return _normalize_explicit_shapes(shape, chunks, shards)
 
@@ -248,40 +246,44 @@ def _normalize_explicit_shapes(
     return resolved_chunks, resolved_shards
 
 
-def _default_chunks_and_shards(
-    shape: ChunkShape,
-) -> tuple[ChunkShape, ChunkShape]:
-    """Return the library default chunk and shard layout for a 3D CT volume.
+def _power_of_two_edge(elements: int, dimensions: int) -> int:
+    """Return the power-of-two edge whose volume is closest to the target."""
+    if isinstance(elements, bool) or elements <= 0:
+        raise ValueError(f"elements must be a positive integer. Got {elements}.")
 
-    Volumes use 32-cubed chunks by default, while single-slice data uses larger
-    in-plane chunks. Shards keep one chunk along z and span each in-plane axis,
-    rounded up to a chunk multiple for valid zarr sharding.
-    """
-    default_chunks, default_shards = (
-        (_DEFAULT_2D_ZARR_CHUNKS, _DEFAULT_2D_ZARR_SHARDS)
-        if shape[0] == 1
-        else (_DEFAULT_3D_ZARR_CHUNKS, _DEFAULT_3D_ZARR_SHARDS)
+    edge = 1
+    while (edge * 2) ** dimensions <= elements:
+        edge *= 2
+    larger_edge = edge * 2
+    if larger_edge**dimensions - elements < elements - edge**dimensions:
+        return larger_edge
+    return edge
+
+
+def _auto_shape(shape: ChunkShape, elements: int) -> ChunkShape:
+    """Return a power-of-two square or cubic shape, trimmed to the array."""
+    is_2d = len(shape) == 3 and shape[0] == 1
+    dimensions = 2 if is_2d else len(shape)
+    edge = _power_of_two_edge(elements, dimensions)
+    return tuple(
+        axis_size if is_2d and axis == 0 else min(edge, axis_size)
+        for axis, axis_size in enumerate(shape)
     )
-    inner_chunks = tuple(
-        min(chunk_size, axis_size)
-        for chunk_size, axis_size in zip(default_chunks, shape, strict=True)
+
+
+def _auto_shards(
+    shape: ChunkShape,
+    chunks: ChunkShape,
+    elements: int,
+) -> ChunkShape:
+    """Return auto shard dimensions trimmed to the array and aligned to chunks."""
+    target = _auto_shape(shape, elements)
+    return tuple(
+        shard_size
+        if chunk_size == 0
+        else _round_up_to_multiple(max(chunk_size, shard_size), chunk_size)
+        for shard_size, chunk_size in zip(target, chunks, strict=True)
     )
-    clamped_shards = tuple(
-        0
-        if shard_size == 0
-        else max(
-            chunk_size,
-            min(shard_size, _round_up_to_multiple(axis_size, chunk_size)),
-        )
-        for shard_size, axis_size, chunk_size in zip(
-            default_shards, shape, inner_chunks, strict=True
-        )
-    )
-    resolved_chunks, resolved_shards = _normalize_explicit_shapes(
-        shape, inner_chunks, clamped_shards
-    )
-    assert resolved_shards is not None
-    return resolved_chunks, resolved_shards
 
 
 def _build_mango_attrs(

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -33,7 +33,7 @@ class OMEZarrVersion(Enum):
     v05 = "0.5"
 
 
-# TODO: 2.0.0 Force kwargs-only for optional paramrs
+# TODO: 2.0.0 Force kwargs-only for optional parameters
 def dataset_to_zarr(
     dataset: Dataset,
     path: Path | str,

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -33,15 +33,17 @@ class OMEZarrVersion(Enum):
     v05 = "0.5"
 
 
+# TODO: 2.0.0 Force kwargs-only for optional paramrs
 def dataset_to_zarr(
     dataset: Dataset,
     path: Path | str,
     datatype: DataType | str | None = None,
     dataset_id: str | None = None,
     ome_zarr_version: OMEZarrVersion | None = OMEZarrVersion.v05,
-    max_shard_size_mb: float | None = None,
+    max_shard_size_mb: float
+    | None = None,  # TODO: 2.0.0 Remove this deprecated parameter
     history: History | None = None,
-    chunk_size_mb: float | None = None,
+    chunk_size_mb: float | None = None,  # TODO: 2.0.0 Remove this deprecated parameter
     chunks: ChunkSpec = "auto",
     shards: ShardSpec = "auto",
     create_array_kwargs: dict[str, Any] | None = None,

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -75,7 +75,7 @@ def dataset_to_zarr(
         An integer specifies the target number of elements for an automatically derived layout.
         ``'auto'`` uses a default target corresponding to ``32**3`` or ``256**2`` elements.
         To write without sharding, pass ``shards=None`` explicitly.
-        A value of ``0`` in a shape tuple  means "span this axis" - the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
+        A value of ``0`` in a shape tuple means "span this axis" — the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
     :param shards: Explicit shard shape as a tuple shape (e.g., ``(100, 512, 512)``), int (target # of elements), or ``'auto'``.
         May be provided together with an explicit ``chunks`` tuple.
         Providing an explicit shard shape with ``chunks='auto'`` is an error.

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -108,7 +108,7 @@ def test_write_without_datatype(_make_dataset):
         assert np.allclose(read_dataset.voxel_size, (1.0, 1.0, 1.0))
 
 
-def test_write_split_zarr(_make_dataset):
+def test_write_zarr_deprecated_size_args_warn_and_use_default_layout(_make_dataset):
     """Deprecated size-based parameters warn and fall back to the default layout."""
     import zarr
 

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -109,44 +109,34 @@ def test_write_without_datatype(_make_dataset):
 
 
 def test_write_split_zarr(_make_dataset):
-    """Test writing sharded Zarr stores (replaces old split store functionality)."""
-    shape = (100, 20, 30)
+    """Deprecated size-based parameters warn and fall back to the default layout."""
+    import zarr
+
+    shape = (100, 20, 60)
     dataset, data = _make_dataset(shape, chunks=(10, 20, 30))
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "test_sharded.zarr"
 
-        # Write with max shard size to create multiple shard files
-        # Each z-slice is 20*30*2 bytes = 1200 bytes = 0.0011 MB
-        # Set max_shard_size_mb to 0.02 MB and chunk_size_mb to 0.005 MB
-        # This should create multiple shard files
-        anu_ctlab_io.zarr.dataset_to_zarr(
-            dataset,
-            output_path,
-            dataset_id="test_sharded_dataset",
-            max_shard_size_mb=0.02,
-            chunk_size_mb=0.005,
-        )
+        with pytest.warns(
+            UserWarning,
+            match="chunk_size_mb, max_shard_size_mb is ignored when writing Zarr",
+        ):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                output_path,
+                dataset_id="test_sharded_dataset",
+                max_shard_size_mb=0.02,
+                chunk_size_mb=0.005,
+            )
 
-        # Check zarr was created
-        assert output_path.exists()
-        assert output_path.is_dir()
+        array = zarr.open_array(output_path / "0", mode="r")
+        assert array.chunks == (32, 20, 32)
+        assert array.shards == (32, 20, 64)
 
-        # Check multiple shard files exist
-        shard_files = list(output_path.glob("0/c/**/*"))
-        assert len(shard_files) > 1, (
-            f"Expected multiple shard files, got {len(shard_files)}"
-        )
-
-        # Verify it can be read back correctly
         loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert loaded_dataset.data.shape == shape
-        assert loaded_dataset.voxel_unit == anu_ctlab_io.VoxelUnit.MM
-
-        # Verify data integrity
-        original_sum = data.sum().compute()
-        loaded_sum = loaded_dataset.data.sum().compute()
-        assert np.isclose(original_sum, loaded_sum)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
 
 
 def test_roundtrip_against_reference():
@@ -323,6 +313,7 @@ def test_write_explicit_shapes_roundtrip(_make_dataset):
         assert np.allclose(read_dataset.voxel_size, dataset.voxel_size)
 
 
+@pytest.mark.xfail(reason="This was the behaviour in <=1.2.2, but it is not useful")
 def test_error_chunks_without_shards(_make_dataset):
     """Test that providing chunks without shards raises ValueError."""
     dataset, _ = _make_dataset(
@@ -351,14 +342,29 @@ def test_error_shards_without_chunks(_make_dataset):
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "test.zarr"
 
-        with pytest.raises(ValueError, match="chunks and shards must both be provided"):
+        with pytest.raises(
+            ValueError, match="shards cannot be provided without explicit chunks"
+        ):
             anu_ctlab_io.zarr.dataset_to_zarr(
                 dataset,
                 output_path,
                 shards=(10, 20, 30),
             )
 
+        with pytest.raises(
+            ValueError, match="shards cannot be provided without explicit chunks"
+        ):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                output_path,
+                chunks="auto",
+                shards=(10, 20, 30),
+            )
 
+
+@pytest.mark.xfail(
+    reason="This was the behaviour in <=1.2.2, but this library now ignores size parameters"
+)
 def test_error_both_shapes_and_sizes(_make_dataset):
     """Test that providing both shapes and sizes raises ValueError."""
     dataset, _ = _make_dataset(
@@ -381,6 +387,9 @@ def test_error_both_shapes_and_sizes(_make_dataset):
             )
 
 
+@pytest.mark.xfail(
+    reason="This was the behaviour in <=1.2.2, but this library now ignores size parameters"
+)
 def test_error_shapes_and_max_shard_size(_make_dataset):
     """Test that providing shapes with max_shard_size_mb raises ValueError."""
     dataset, _ = _make_dataset(
@@ -566,14 +575,23 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
                 max_shard_size_mb=1.0,  # Small shards to trigger remainder
             )
 
-            # Verify no PerformanceWarning was raised (it should be suppressed)
+            # Verify the deprecated size warning is the only warning emitted.
             perf_warnings = [
                 warning
                 for warning in w
-                if issubclass(warning.category, PerformanceWarning | UserWarning)
+                if issubclass(warning.category, PerformanceWarning)
             ]
             assert len(perf_warnings) == 0, (
-                f"Unexpected warnings raised: {[str(w.message) for w in perf_warnings]}"
+                f"Unexpected performance warnings raised: {[str(w.message) for w in perf_warnings]}"
+            )
+
+            user_warnings = [
+                warning for warning in w if issubclass(warning.category, UserWarning)
+            ]
+            assert len(user_warnings) == 1
+            assert (
+                "chunk_size_mb, max_shard_size_mb is ignored when writing Zarr"
+                in str(user_warnings[0].message)
             )
 
         # Verify the write succeeded and data is correct
@@ -581,3 +599,155 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
         read_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert read_dataset.data.shape == shape
         assert np.array_equal(read_dataset.data.compute(), data.compute())
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "shards", "expected_chunks", "expected_shards"),
+    [
+        ((40, 65, 97), "auto", "auto", (32, 32, 32), (32, 96, 128)),
+        ((1, 600, 700), "auto", "auto", (1, 256, 256), (1, 768, 768)),
+        ((21, 200, 300), "auto", "auto", (21, 32, 32), (21, 224, 320)),
+        ((60, 40, 50), (10, 0, 25), (30, 0, 0), (10, 40, 25), (30, 40, 50)),
+        ((1000, 512, 512), "auto", "auto", (32, 32, 32), (32, 512, 512)),
+        ((10, 20, 30), (5, 20, 30), (10, 20, 30), (5, 20, 30), (10, 20, 30)),
+        ((40, 65, 97), "auto", None, (32, 32, 32), None),
+        ((10, 20, 30), "auto", "auto", (10, 20, 30), (10, 20, 30)),
+        ((10, 20, 30), (5, 0, 0), None, (5, 20, 30), None),
+        ((40, 65, 97), (32, 32, 32), (32, 0, 0), (32, 32, 32), (32, 96, 128)),
+    ],
+)
+def test_resolve_zarr_layout(
+    shape,
+    chunks,
+    shards,
+    expected_chunks,
+    expected_shards,
+):
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=shape,
+        chunks=chunks,
+        shards=shards,
+    )
+
+    assert chunks == expected_chunks
+    assert shards == expected_shards
+
+
+def test_zero_chunk_and_shard_axes_expand_to_span_targets(_make_dataset):
+    """A zero in shards spans the array; a zero in chunks spans the resolved shard axis."""
+    import zarr
+
+    dataset, _ = _make_dataset((60, 40, 50))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "shapes_with_zero.zarr"
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            chunks=(10, 0, 25),
+            shards=(30, 0, 0),
+            ome_zarr_version=None,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.chunks == (10, 40, 25)
+        assert array.shards == (30, 40, 50)
+
+
+def test_default_zarr_chunking_spans_xy_domain(_make_dataset):
+    """Default Zarr writing uses 32^3 subchunks with full-domain XY chunks (shards)."""
+    import zarr
+
+    dataset, _ = _make_dataset((40, 65, 97))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "default_layout.zarr"
+
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.chunks == (32, 32, 32)
+        assert array.shards == (32, 96, 128)
+
+
+def test_write_with_auto_chunks(_make_dataset):
+    """Passing chunks='auto' with shards=None uses the default unsharded chunk layout."""
+    import zarr
+
+    dataset, data = _make_dataset((10, 20, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "auto_chunks.zarr"
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+            chunks="auto",
+            shards=None,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.shards is None
+        assert array.chunks == (10, 20, 32)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_write_with_auto_chunks_and_shards(_make_dataset):
+    """Passing chunks='auto' and shards='auto' uses the default sharded layout."""
+    import zarr
+
+    shape = (100, 20, 60)
+    dataset, data = _make_dataset(shape, chunks=(10, 20, 30))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "auto_chunks_and_shards.zarr"
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+            chunks="auto",
+            shards="auto",
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.chunks == (32, 20, 32)
+        assert array.shards == (32, 20, 64)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_size_parameters_warn_and_explicit_shapes_still_win(_make_dataset):
+    """Deprecated size parameters are ignored when explicit shapes are also provided."""
+    import zarr
+
+    dataset, data = _make_dataset((60, 40, 50))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "explicit_shapes_with_ignored_sizes.zarr"
+        with pytest.warns(
+            UserWarning,
+            match="chunk_size_mb, max_shard_size_mb is ignored when writing Zarr",
+        ):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                output_path,
+                ome_zarr_version=None,
+                chunks=(10, 40, 50),
+                shards=(30, 40, 50),
+                chunk_size_mb=0.005,
+                max_shard_size_mb=1.0,
+            )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.chunks == (10, 40, 50)
+        assert array.shards == (30, 40, 50)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -120,7 +120,7 @@ def test_write_zarr_deprecated_size_args_warn_and_use_default_layout(_make_datas
 
         with pytest.warns(
             UserWarning,
-            match="chunk_size_mb, max_shard_size_mb is ignored when writing Zarr",
+            match="chunk_size_mb, max_shard_size_mb are ignored when writing Zarr",
         ):
             anu_ctlab_io.zarr.dataset_to_zarr(
                 dataset,
@@ -590,7 +590,7 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
             ]
             assert len(user_warnings) == 1
             assert (
-                "chunk_size_mb, max_shard_size_mb is ignored when writing Zarr"
+                "chunk_size_mb, max_shard_size_mb are ignored when writing Zarr"
                 in str(user_warnings[0].message)
             )
 
@@ -733,7 +733,7 @@ def test_size_parameters_warn_and_explicit_shapes_still_win(_make_dataset):
         output_path = Path(tmpdir) / "explicit_shapes_with_ignored_sizes.zarr"
         with pytest.warns(
             UserWarning,
-            match="chunk_size_mb, max_shard_size_mb is ignored when writing Zarr",
+            match="chunk_size_mb, max_shard_size_mb are ignored when writing Zarr",
         ):
             anu_ctlab_io.zarr.dataset_to_zarr(
                 dataset,

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -108,8 +108,8 @@ def test_write_without_datatype(_make_dataset):
         assert np.allclose(read_dataset.voxel_size, (1.0, 1.0, 1.0))
 
 
-def test_write_zarr_deprecated_size_args_warn_and_use_default_layout(_make_dataset):
-    """Deprecated size-based parameters warn and fall back to the default layout."""
+def test_write_zarr_element_targets_control_auto_layout(_make_dataset):
+    """Integer chunk and shard specs control automatic layouts by element count."""
     import zarr
 
     shape = (100, 20, 60)
@@ -118,21 +118,17 @@ def test_write_zarr_deprecated_size_args_warn_and_use_default_layout(_make_datas
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "test_sharded.zarr"
 
-        with pytest.warns(
-            UserWarning,
-            match="chunk_size_mb, max_shard_size_mb are ignored when writing Zarr",
-        ):
-            anu_ctlab_io.zarr.dataset_to_zarr(
-                dataset,
-                output_path,
-                dataset_id="test_sharded_dataset",
-                max_shard_size_mb=0.02,
-                chunk_size_mb=0.005,
-            )
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            dataset_id="test_sharded_dataset",
+            chunks=8**3,
+            shards=16**3,
+        )
 
         array = zarr.open_array(output_path / "0", mode="r")
-        assert array.chunks == (32, 20, 32)
-        assert array.shards == (32, 20, 64)
+        assert array.chunks == (8, 8, 8)
+        assert array.shards == (16, 16, 16)
 
         loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert loaded_dataset.data.shape == shape
@@ -362,11 +358,10 @@ def test_error_shards_without_chunks(_make_dataset):
             )
 
 
-@pytest.mark.xfail(
-    reason="This was the behaviour in <=1.2.2, but this library now ignores size parameters"
-)
-def test_error_both_shapes_and_sizes(_make_dataset):
-    """Test that providing both shapes and sizes raises ValueError."""
+def test_explicit_shapes_ignore_deprecated_chunk_size(_make_dataset):
+    """Deprecated size parameters are ignored when explicit shapes are provided."""
+    import zarr
+
     dataset, _ = _make_dataset(
         (10, 20, 30),
         data=np.zeros((10, 20, 30), dtype=np.uint16),
@@ -375,9 +370,7 @@ def test_error_both_shapes_and_sizes(_make_dataset):
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "test.zarr"
 
-        with pytest.raises(
-            ValueError, match="Cannot specify both chunks/shards and chunk_size_mb"
-        ):
+        with pytest.warns(UserWarning, match="chunk_size_mb is ignored"):
             anu_ctlab_io.zarr.dataset_to_zarr(
                 dataset,
                 output_path,
@@ -386,12 +379,15 @@ def test_error_both_shapes_and_sizes(_make_dataset):
                 chunk_size_mb=5.0,
             )
 
+        array = zarr.open_array(output_path / "0", mode="r")
+        assert array.chunks == (5, 20, 30)
+        assert array.shards == (10, 20, 30)
 
-@pytest.mark.xfail(
-    reason="This was the behaviour in <=1.2.2, but this library now ignores size parameters"
-)
-def test_error_shapes_and_max_shard_size(_make_dataset):
-    """Test that providing shapes with max_shard_size_mb raises ValueError."""
+
+def test_auto_shards_ignore_deprecated_max_shard_size(_make_dataset):
+    """Deprecated shard size is ignored when selecting an auto shard layout."""
+    import zarr
+
     dataset, _ = _make_dataset(
         (10, 20, 30),
         data=np.zeros((10, 20, 30), dtype=np.uint16),
@@ -400,16 +396,18 @@ def test_error_shapes_and_max_shard_size(_make_dataset):
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "test.zarr"
 
-        with pytest.raises(
-            ValueError, match="Cannot specify both chunks/shards and chunk_size_mb"
-        ):
+        with pytest.warns(UserWarning, match="max_shard_size_mb is ignored"):
             anu_ctlab_io.zarr.dataset_to_zarr(
                 dataset,
                 output_path,
                 chunks=(5, 20, 30),
-                shards=(10, 20, 30),
-                max_shard_size_mb=100.0,
+                shards="auto",
+                max_shard_size_mb=0.02,
             )
+
+        array = zarr.open_array(output_path / "0", mode="r")
+        assert array.chunks == (5, 20, 30)
+        assert array.shards == (10, 20, 30)
 
 
 def test_user_shapes_used_without_validation(_make_dataset):
@@ -575,7 +573,6 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
                 max_shard_size_mb=1.0,  # Small shards to trigger remainder
             )
 
-            # Verify the deprecated size warning is the only warning emitted.
             perf_warnings = [
                 warning
                 for warning in w
@@ -604,11 +601,11 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
 @pytest.mark.parametrize(
     ("shape", "chunks", "shards", "expected_chunks", "expected_shards"),
     [
-        ((40, 65, 97), "auto", "auto", (32, 32, 32), (32, 96, 128)),
+        ((40, 65, 97), "auto", "auto", (32, 32, 32), (64, 96, 128)),
         ((1, 600, 700), "auto", "auto", (1, 256, 256), (1, 768, 768)),
         ((21, 200, 300), "auto", "auto", (21, 32, 32), (21, 224, 320)),
         ((60, 40, 50), (10, 0, 25), (30, 0, 0), (10, 40, 25), (30, 40, 50)),
-        ((1000, 512, 512), "auto", "auto", (32, 32, 32), (32, 512, 512)),
+        ((1000, 512, 512), "auto", "auto", (32, 32, 32), (512, 512, 512)),
         ((10, 20, 30), (5, 20, 30), (10, 20, 30), (5, 20, 30), (10, 20, 30)),
         ((40, 65, 97), "auto", None, (32, 32, 32), None),
         ((10, 20, 30), "auto", "auto", (10, 20, 30), (10, 20, 30)),
@@ -633,6 +630,103 @@ def test_resolve_zarr_layout(
     assert shards == expected_shards
 
 
+@pytest.mark.parametrize(
+    ("elements", "expected_chunks"),
+    [
+        (32**3, (32, 32, 32)),
+        (64**3, (64, 64, 64)),
+        (64**3 - 1, (64, 64, 64)),
+    ],
+)
+def test_integer_chunks_are_element_based(elements, expected_chunks):
+    chunks, _ = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(1024, 1024, 1024),
+        chunks=elements,
+        shards=None,
+    )
+
+    assert chunks == expected_chunks
+
+
+@pytest.mark.parametrize(
+    ("elements", "expected_chunks"),
+    [
+        (32**2, (1, 32, 32)),
+        (64**2, (1, 64, 64)),
+        (64**2 - 1, (1, 64, 64)),
+    ],
+)
+def test_integer_chunks_are_element_based_for_2d(elements, expected_chunks):
+    chunks, _ = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(1, 1024, 1024),
+        chunks=elements,
+        shards=None,
+    )
+
+    assert chunks == expected_chunks
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_chunks", "expected_shards"),
+    [
+        ((1024, 1024, 1024), (32, 32, 32), (512, 512, 512)),
+        ((1, 65536, 65536), (1, 256, 256), (1, 8192, 8192)),
+    ],
+)
+def test_auto_uses_default_element_targets(shape, expected_chunks, expected_shards):
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=shape,
+        chunks="auto",
+        shards="auto",
+    )
+
+    assert chunks == expected_chunks
+    assert shards == expected_shards
+
+
+def test_integer_shards_are_chunk_multiples():
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(100, 100, 100),
+        chunks=(10, 20, 25),
+        shards=32**3,
+    )
+
+    assert chunks == (10, 20, 25)
+    assert shards == (40, 40, 50)
+
+
+def test_integer_shards_are_chunk_multiples_for_2d():
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(1, 100, 100),
+        chunks=(1, 20, 25),
+        shards=32**2,
+    )
+
+    assert chunks == (1, 20, 25)
+    assert shards == (1, 40, 50)
+
+
+def test_integer_shards_support_zero_chunk_sentinels():
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(100, 100, 100),
+        chunks=(0, 20, 25),
+        shards=32**3,
+    )
+
+    assert chunks == (32, 20, 25)
+    assert shards == (32, 40, 50)
+
+
+@pytest.mark.parametrize("elements", [0, -1, True])
+def test_invalid_element_targets_raise(elements):
+    with pytest.raises(ValueError, match="elements must be a positive integer"):
+        anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+            shape=(100, 100, 100),
+            chunks=elements,
+            shards=None,
+        )
+
+
 def test_zero_chunk_and_shard_axes_expand_to_span_targets(_make_dataset):
     """A zero in shards spans the array; a zero in chunks spans the resolved shard axis."""
     import zarr
@@ -654,8 +748,8 @@ def test_zero_chunk_and_shard_axes_expand_to_span_targets(_make_dataset):
         assert array.shards == (30, 40, 50)
 
 
-def test_default_zarr_chunking_spans_xy_domain(_make_dataset):
-    """Default Zarr writing uses 32^3 subchunks with full-domain XY chunks (shards)."""
+def test_default_zarr_chunking_is_element_based(_make_dataset):
+    """Default Zarr writing uses element-based cubic chunks and shards."""
     import zarr
 
     dataset, _ = _make_dataset((40, 65, 97))
@@ -671,7 +765,7 @@ def test_default_zarr_chunking_spans_xy_domain(_make_dataset):
 
         array = zarr.open_array(output_path, mode="r")
         assert array.chunks == (32, 32, 32)
-        assert array.shards == (32, 96, 128)
+        assert array.shards == (64, 96, 128)
 
 
 def test_write_with_auto_chunks(_make_dataset):
@@ -717,14 +811,14 @@ def test_write_with_auto_chunks_and_shards(_make_dataset):
 
         array = zarr.open_array(output_path, mode="r")
         assert array.chunks == (32, 20, 32)
-        assert array.shards == (32, 20, 64)
+        assert array.shards == (128, 20, 64)
 
         loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert np.array_equal(loaded_dataset.data.compute(), data.compute())
 
 
-def test_size_parameters_warn_and_explicit_shapes_still_win(_make_dataset):
-    """Deprecated size parameters are ignored when explicit shapes are also provided."""
+def test_size_parameters_and_explicit_shapes(_make_dataset):
+    """Deprecated size parameters warn and explicit shapes still win."""
     import zarr
 
     dataset, data = _make_dataset((60, 40, 50))


### PR DESCRIPTION
The previous default chunking [1, Y, X] was highly suboptimal. This changes it to a cubic / square power of two with a sensible sizes for visualisation and processing.

- Default chunks / subchunks:
  - 3D: $512^3$ / $32^3$
  - 2D: $8192^2$ / $256^2$
- Allow specifying 0 for a chunk / shard shape dimension to span the dimension
- Allow specifying chunks without sharding
- Deprecate (ignore and emit a warning) the old size-based chunking parameters that do not have a useful write pattern

Resolves #74

This is more aligned with current mango chunking defaults.