### PR TITLE
feat(zarr): use "." dimension separator with a small number of chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add explicit and automatic Zarr chunk/shard layout selection through `chunks` and `shards`, including integer element targets, `"auto"` defaults, `None` to disable sharding, and `0` tuple entries to span an axis
+- Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"."` as the chunk key encoding separator for arrays with fewer chunks than the threshold (default 64)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add explicit and automatic Zarr chunk/shard layout selection through `chunks` and `shards`, including integer element targets, `"auto"` defaults, `None` to disable sharding, and `0` tuple entries to span an axis
-- Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"."` as the chunk key encoding separator for arrays with fewer chunks than the threshold (default 64)
+- Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"/"` as the chunk key encoding separator when the number of chunks exceeds the threshold (default 64), and `"."` otherwise
 
 ### Changed
 

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -87,9 +87,9 @@ def dataset_to_zarr(
         When provided, the user is responsible for ensuring shard shapes are evenly divisible by chunk shapes.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
         For example, to set compression: ``create_array_kwargs={'compressors': [ZstdCodec(level=5)]}``.
-    :param dimension_separator_threshold: Use ``'.'`` as the chunk key dimension
-        separator when the array has fewer chunks than this threshold; otherwise use
-        ``'/'``. Must be a positive integer, or ``None`` to use the Zarr default of ``'/'``.
+    :param dimension_separator_threshold: Use ``'/'`` as the chunk key dimension
+        separator when the number of chunks exceeds this threshold; otherwise use
+        ``'.'``. ``None`` uses the Zarr default of ``'/'``.
     :param extra_attrs: Additional attributes to include in mango metadata.
     """
     if isinstance(path, str):
@@ -190,7 +190,7 @@ def _chunk_key_encoding(
         (axis_size + chunk_size - 1) // chunk_size
         for axis_size, chunk_size in zip(shape, chunks, strict=True)
     )
-    separator = "." if num_chunks < dimension_separator_threshold else "/"
+    separator = "/" if num_chunks > dimension_separator_threshold else "."
     return {"name": "default", "separator": separator}
 
 

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -3,6 +3,7 @@
 import warnings
 from datetime import datetime
 from enum import Enum
+from math import prod
 from pathlib import Path
 from typing import Any, Literal
 
@@ -47,6 +48,7 @@ def dataset_to_zarr(
     chunks: ChunkSpec = "auto",
     shards: ShardSpec = "auto",
     create_array_kwargs: dict[str, Any] | None = None,
+    dimension_separator_threshold: int | None = 64,
     **extra_attrs: Any,
 ) -> None:
     """Write a :any:`Dataset` to Zarr format.
@@ -85,6 +87,9 @@ def dataset_to_zarr(
         When provided, the user is responsible for ensuring shard shapes are evenly divisible by chunk shapes.
     :param create_array_kwargs: Additional keyword arguments to pass to zarr.create_array().
         For example, to set compression: ``create_array_kwargs={'compressors': [ZstdCodec(level=5)]}``.
+    :param dimension_separator_threshold: Use ``'.'`` as the chunk key dimension
+        separator when the array has fewer chunks than this threshold; otherwise use
+        ``'/'``. Must be a positive integer, or ``None`` to use the Zarr default of ``'/'``.
     :param extra_attrs: Additional attributes to include in mango metadata.
     """
     if isinstance(path, str):
@@ -136,8 +141,14 @@ def dataset_to_zarr(
             dataset, datatype, dataset_id, history, extra_attrs
         )
 
-    if create_array_kwargs is None:
-        create_array_kwargs = {}
+    create_array_kwargs = dict(create_array_kwargs or {})
+    if dimension_separator_threshold is not None:
+        # Use outer_shards for chunk key encoding calculation when sharding is
+        # enabled, since Zarr's chunk_key_encoding addresses shards, not inner chunks.
+        _key_chunks = outer_shards if outer_shards is not None else inner_chunks
+        create_array_kwargs["chunk_key_encoding"] = _chunk_key_encoding(
+            data_array.shape, _key_chunks, dimension_separator_threshold
+        )
 
     if ome_zarr_version is not None:
         _write_ome_zarr_group(
@@ -169,6 +180,18 @@ def _round_up_to_multiple(value: int, multiple: int) -> int:
             "The array likely has a zero-length axis, which is not supported."
         )
     return ((value + multiple - 1) // multiple) * multiple
+
+
+def _chunk_key_encoding(
+    shape: ChunkShape, chunks: ChunkShape, dimension_separator_threshold: int
+) -> dict[str, str]:
+    """Use flat chunk keys for small arrays and nested keys for larger arrays."""
+    num_chunks = prod(
+        (axis_size + chunk_size - 1) // chunk_size
+        for axis_size, chunk_size in zip(shape, chunks, strict=True)
+    )
+    separator = "." if num_chunks < dimension_separator_threshold else "/"
+    return {"name": "default", "separator": separator}
 
 
 def _resolve_zarr_layout(

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -83,15 +83,17 @@ def test_write_single_zarr_array(_make_dataset):
     ("ome_zarr_version", "num_chunks", "expected_separator"),
     [
         (None, 63, "."),
-        (None, 64, "/"),
+        (None, 64, "."),
+        (None, 65, "/"),
         (OMEZarrVersion.v05, 63, "."),
-        (OMEZarrVersion.v05, 64, "/"),
+        (OMEZarrVersion.v05, 64, "."),
+        (OMEZarrVersion.v05, 65, "/"),
     ],
 )
 def test_chunk_key_separator_depends_on_number_of_chunks(
     _make_dataset, ome_zarr_version, num_chunks, expected_separator
 ):
-    """Use flat chunk keys only when the array has fewer than 64 chunks."""
+    """Use flat chunk keys when the number of chunks does not exceed the threshold."""
     dataset, _ = _make_dataset((num_chunks, 1, 1), chunks=(1, 1, 1))
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -119,9 +121,11 @@ def test_chunk_key_separator_depends_on_number_of_chunks(
     ("ome_zarr_version", "num_shards", "expected_separator"),
     [
         (None, 63, "."),
-        (None, 64, "/"),
+        (None, 64, "."),
+        (None, 65, "/"),
         (OMEZarrVersion.v05, 63, "."),
-        (OMEZarrVersion.v05, 64, "/"),
+        (OMEZarrVersion.v05, 64, "."),
+        (OMEZarrVersion.v05, 65, "/"),
     ],
 )
 def test_chunk_key_separator_uses_shards_when_sharded(

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -9,14 +10,11 @@ try:
     from dask.array.core import PerformanceWarning
 
     import anu_ctlab_io.zarr
-
-    _HAS_ZARR = True
+    from anu_ctlab_io.zarr import OMEZarrVersion
 except ImportError:
-    _HAS_ZARR = False
+    pytest.skip("Requires 'zarr' extra", allow_module_level=True)
 
 import anu_ctlab_io
-
-pytestmark = pytest.mark.skipif(not _HAS_ZARR, reason="Requires 'zarr' extra")
 
 
 def test_write_single_ome_zarr(_make_dataset):
@@ -32,7 +30,7 @@ def test_write_single_ome_zarr(_make_dataset):
             dataset,
             output_path,
             dataset_id="test_dataset",
-            ome_zarr_version=anu_ctlab_io.zarr.OMEZarrVersion.v05,
+            ome_zarr_version=OMEZarrVersion.v05,
         )
 
         # Verify file exists
@@ -79,6 +77,116 @@ def test_write_single_zarr_array(_make_dataset):
         assert np.allclose(read_dataset.voxel_size, dataset.voxel_size)
         assert np.array_equal(read_dataset.data.compute(), data.compute())
         assert read_dataset.dimension_names == dataset.dimension_names
+
+
+@pytest.mark.parametrize(
+    ("ome_zarr_version", "num_chunks", "expected_separator"),
+    [
+        (None, 63, "."),
+        (None, 64, "/"),
+        (OMEZarrVersion.v05, 63, "."),
+        (OMEZarrVersion.v05, 64, "/"),
+    ],
+)
+def test_chunk_key_separator_depends_on_number_of_chunks(
+    _make_dataset, ome_zarr_version, num_chunks, expected_separator
+):
+    """Use flat chunk keys only when the array has fewer than 64 chunks."""
+    dataset, _ = _make_dataset((num_chunks, 1, 1), chunks=(1, 1, 1))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "separator.zarr"
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=ome_zarr_version,
+            chunks=(1, 1, 1),
+            shards=None,
+            slice_thumbnails=False,
+        )
+
+        metadata_path = output_path / "zarr.json"
+        if ome_zarr_version is not None:
+            metadata_path = output_path / "0" / "zarr.json"
+        metadata = json.loads(metadata_path.read_text())
+        assert (
+            metadata["chunk_key_encoding"]["configuration"]["separator"]
+            == expected_separator
+        )
+
+
+@pytest.mark.parametrize(
+    ("ome_zarr_version", "num_shards", "expected_separator"),
+    [
+        (None, 63, "."),
+        (None, 64, "/"),
+        (OMEZarrVersion.v05, 63, "."),
+        (OMEZarrVersion.v05, 64, "/"),
+    ],
+)
+def test_chunk_key_separator_uses_shards_when_sharded(
+    _make_dataset, ome_zarr_version, num_shards, expected_separator
+):
+    """Use flat chunk keys based on number of shards, not inner chunks, when sharded."""
+    # Create an array where inner chunks would be >64 but shards are <64.
+    dataset, _ = _make_dataset((num_shards, 1, 1), chunks=(1, 1, 1))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "separator_sharded.zarr"
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=ome_zarr_version,
+            chunks=(1, 1, 1),
+            shards=(1, 1, 1),
+            slice_thumbnails=False,
+        )
+
+        metadata_path = output_path / "zarr.json"
+        if ome_zarr_version is not None:
+            metadata_path = output_path / "0" / "zarr.json"
+        metadata = json.loads(metadata_path.read_text())
+        assert (
+            metadata["chunk_key_encoding"]["configuration"]["separator"]
+            == expected_separator
+        )
+
+
+def test_dimension_separator_threshold_can_be_overridden(_make_dataset, tmp_path):
+    """The dimension separator threshold can be configured by the caller."""
+    dataset, _ = _make_dataset((20, 1, 1), chunks=(1, 1, 1))
+    output_path = tmp_path / "separator.zarr"
+
+    dataset.to_path(
+        output_path,
+        ome_zarr_version=None,
+        chunks=(1, 1, 1),
+        shards=None,
+        slice_thumbnails=False,
+        dimension_separator_threshold=21,
+    )
+
+    metadata = json.loads((output_path / "zarr.json").read_text())
+    assert metadata["chunk_key_encoding"]["configuration"]["separator"] == "."
+
+
+def test_none_dimension_separator_threshold_uses_zarr_default(_make_dataset, tmp_path):
+    """A None threshold leaves chunk key encoding selection to Zarr."""
+    dataset, _ = _make_dataset((1, 1, 1), chunks=(1, 1, 1))
+    output_path = tmp_path / "separator.zarr"
+
+    anu_ctlab_io.zarr.dataset_to_zarr(
+        dataset,
+        output_path,
+        ome_zarr_version=None,
+        chunks=(1, 1, 1),
+        shards=None,
+        slice_thumbnails=False,
+        dimension_separator_threshold=None,
+    )
+
+    metadata = json.loads((output_path / "zarr.json").read_text())
+    assert metadata["chunk_key_encoding"]["configuration"]["separator"] == "/"
 
 
 def test_write_without_datatype(_make_dataset):
@@ -179,7 +287,7 @@ def test_roundtrip_ome_zarr():
             output_path,
             datatype=anu_ctlab_io.DataType.TOMO,
             dataset_id="ome_roundtrip_test",
-            ome_zarr_version=anu_ctlab_io.zarr.OMEZarrVersion.v05,
+            ome_zarr_version=OMEZarrVersion.v05,
         )
 
         # Read it back


### PR DESCRIPTION
This is mainly to reduce our inodes. E.g. a tiny tomoLoRes with one chunk becomes:

```
.
├── 0
│   ├── c.0.0.0
│   └── zarr.json
└── zarr.json
```

instead of

```
.
├── 0
│   ├── c
│   │   └── 0
│   │       └── 0
│   │           └── 0
│   └── zarr.json
└── zarr.json
```

We can't have `.` as a default because filesystems / HTTP listing perform worse with large directories.