### PR TITLE
fix: handle boolean attributes in netCDF writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change automatic Zarr layouts to use power-of-two square or cubic shapes targeting $32^3$ / $256^2$ subchunks and $512^3$ / $8192$ chunks, trimmed to the dataset shape with subchunks aligned to chunk multiples
 
+### Fixed
+
+- Fix netCDF writing with boolean dataset attributes
+
 ### Deprecated
 
 - Deprecate `chunk_size_mb` and `max_shard_size_mb` for Zarr writing; these parameters are now ignored with a warning

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -150,16 +150,18 @@ def _set_global_attributes(
     for key, value in common_attrs.items():  # NOTE: h5netcdf lacks setncatts
         # h5netcdf stores Python str as UTF-8 NC_STRING; encode to bytes so it
         # is stored as ASCII NC_CHAR, matching what the reference files use.
-        ncfile.setncattr(
-            key, np.bytes_(value.encode("ascii")) if isinstance(value, str) else value
-        )
+        # Booleans are not supported by NetCDF, so convert to int.
+        if isinstance(value, str):
+            value = np.bytes_(value.encode("ascii"))
+        elif isinstance(value, bool):
+            value = np.int_(int(value))
+        ncfile.setncattr(key, value)
 
     if include_history and serialized_history:
         for key, value in serialized_history.items():
-            ncfile.setncattr(
-                f"history_{key}",
-                np.bytes_(value.encode("ascii")) if isinstance(value, str) else value,
-            )
+            if isinstance(value, str):
+                value = np.bytes_(value.encode("ascii"))
+            ncfile.setncattr(f"history_{key}", value)
 
 
 def _create_data_variable(


### PR DESCRIPTION
Fixes `CompatibilityError: boolean dtypes are not a supported NetCDF feature, and are not allowed by h5netcdf unless invalid_netcdf=True.`