### PR TITLE
fix(netCDF): match mango default block size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"/"` as the chunk key encoding separator when the number of chunks exceeds the threshold (default 64), and `"."` otherwise
 - Allow opening of plain Zarr arrays with no `"mango"` attributes
   - The voxel size of such datasets is (1, 1, 1) with `VOXEL` units
-- Add `elements_per_file` parameter to `dataset_to_netcdf` matching the `mango` default
+- Add `elements_per_file` and `mango_compatible_slices_per_file_rounding` parameter to `dataset_to_netcdf` matching the `mango` default
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"/"` as the chunk key encoding separator when the number of chunks exceeds the threshold (default 64), and `"."` otherwise
 - Allow opening of plain Zarr arrays with no `"mango"` attributes
   - The voxel size of such datasets is (1, 1, 1) with `VOXEL` units
+- Add `elements_per_file` parameter to `dataset_to_netcdf` matching the `mango` default
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecate `chunk_size_mb` and `max_shard_size_mb` for Zarr writing; these parameters are now ignored with a warning
+- Deprecate `max_file_size_mb` for NetCDF writing; ignored with a warning
 
 ## [1.2.2] - 2026-04-07
 

--- a/benches/test_write.py
+++ b/benches/test_write.py
@@ -9,7 +9,7 @@ import anu_ctlab_io.raw
 import anu_ctlab_io.zarr
 
 SHAPE = (1024, 512, 512)
-MAX_FILE_SIZE_MB = 256
+ELEMENTS_PER_FILE = 256 * 1024 * 1024
 
 
 @pytest.fixture(scope="module")
@@ -39,7 +39,7 @@ def test_write_netcdf(benchmark, dataset, tmp_path):
             dataset,
             tmp_path / "tomoOut_nc",
             compression_level=0,
-            max_file_size_mb=MAX_FILE_SIZE_MB,
+            elements_per_file=ELEMENTS_PER_FILE,
         )
 
     benchmark.pedantic(write, rounds=1, iterations=1)
@@ -56,7 +56,7 @@ def test_write_netcdf_distributed(benchmark, dataset, tmp_path):
                 dataset,
                 tmp_path / "tomoOut_nc",
                 compression_level=0,
-                max_file_size_mb=MAX_FILE_SIZE_MB,
+                elements_per_file=ELEMENTS_PER_FILE,
             )
 
         benchmark.pedantic(write, rounds=1, iterations=1)
@@ -71,8 +71,8 @@ def test_write_zarr(benchmark, dataset, tmp_path):
     Compressor is different (zstd vs zlib), but performance should be comparable
     """
     shape = SHAPE
-    bytes_per_slice = shape[1] * shape[2] * np.dtype(np.float32).itemsize
-    slices_per_block = max(1, int((MAX_FILE_SIZE_MB * 1024 * 1024) / bytes_per_slice))
+    elements_per_slice = shape[1] * shape[2]
+    slices_per_block = max(1, int(ELEMENTS_PER_FILE / elements_per_slice))
     chunks = (slices_per_block, shape[1], shape[2])
 
     def write():

--- a/examples/create_large_netcdf/src/create_large_netcdf/__init__.py
+++ b/examples/create_large_netcdf/src/create_large_netcdf/__init__.py
@@ -10,7 +10,7 @@ import anu_ctlab_io
 import anu_ctlab_io.netcdf
 
 SHAPE = (10000, 3000, 3000)
-MAX_FILE_SIZE_MB = 500
+ELEMENTS_PER_FILE = 256 * 1024 * 1024
 
 
 def run(client: Client) -> None:
@@ -50,7 +50,7 @@ def run(client: Client) -> None:
         dataset,
         output_dir / "tomoHiRes_nc",
         compression_level=0,
-        max_file_size_mb=MAX_FILE_SIZE_MB,
+        elements_per_file=ELEMENTS_PER_FILE,
     )
 
 

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -19,11 +20,14 @@ from anu_ctlab_io._parse_history import History, serialize_history
 def dataset_to_netcdf(
     dataset: Dataset,
     path: Path | str,
+    # *, # FIXME: Add this on breaking release
     datatype: DataType | str | None = None,
     dataset_id: str | None = None,
-    max_file_size_mb: float | None = 500.0,
+    max_file_size_mb: float | None = None,
     compression_level: int = 0,
     history: History | None = None,
+    # elements_per_file is the mango default of 256 MB per file (mango ignores the element size).
+    elements_per_file: int | None = 256 * 1024 * 1024,
     **extra_attrs: Any,
 ) -> None:
     """Write a :any:`Dataset` to netcdf format.
@@ -32,13 +36,22 @@ def dataset_to_netcdf(
     :param path: Path to write the netcdf file or directory (if splitting).
     :param datatype: Data type identifier. Inferred from dataset if None.
     :param dataset_id: Unique dataset identifier. Auto-generated if not provided.
-    :param max_file_size_mb: Max file size in MB. Data exceeding this is split into
-        multiple files along z-axis. Default 500MB. Set to None for single file.
+    :param max_file_size_mb: Deprecated, ignored. Use ``elements_per_file`` instead.
     :param compression_level: NetCDF compression level (0-9). Default 0 (no compression).
     :param history: History entries to add. Keys are identifiers, values are strings
         or parsed history dicts. If None, uses dataset's history attribute.
+    :param elements_per_file: Number (approximate) of array elements per file.
+        Large arrays are split into multiple files along z-axis.
+        Set to None for single file output. Matches the mango default.
     :param extra_attrs: Additional global attributes to include.
     """
+    if max_file_size_mb is not None:
+        warnings.warn(
+            "max_file_size_mb is deprecated and ignored. Use elements_per_file instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if isinstance(path, str):
         path = Path(path)
 
@@ -90,12 +103,12 @@ def dataset_to_netcdf(
         **extra_attrs,
     }
 
-    # Determine split strategy
-    if max_file_size_mb is not None:
-        bytes_per_slice = ydim * xdim * np.dtype(datatype._dtype_uncorrected).itemsize
-        slices_per_file = max(
-            1, int((max_file_size_mb * 1024 * 1024) / bytes_per_slice)
-        )
+    # Determine split strategy using mega-elements per file (matches mango default)
+    if elements_per_file is not None:
+        elements_per_slice = ydim * xdim
+        slices_per_file = min(
+            zdim, 1 + int((elements_per_file - 1) // elements_per_slice)
+        )  # Matches mango `slicesPerFile` calculation
 
         if zdim > slices_per_file:
             _write_split_netcdf(

--- a/src/anu_ctlab_io/netcdf/_writer.py
+++ b/src/anu_ctlab_io/netcdf/_writer.py
@@ -28,6 +28,7 @@ def dataset_to_netcdf(
     history: History | None = None,
     # elements_per_file is the mango default of 256 MB per file (mango ignores the element size).
     elements_per_file: int | None = 256 * 1024 * 1024,
+    mango_compatible_slices_per_file_rounding: bool = True,
     **extra_attrs: Any,
 ) -> None:
     """Write a :any:`Dataset` to netcdf format.
@@ -43,6 +44,10 @@ def dataset_to_netcdf(
     :param elements_per_file: Number (approximate) of array elements per file.
         Large arrays are split into multiple files along z-axis.
         Set to None for single file output. Matches the mango default.
+    :param mango_compatible_slices_per_file_rounding: If True, rounds slices per file calculated from
+        ``elements_per_file`` to a value divisible by common factors
+        (2, 4, 6, 8, 12, 16, 24, 40, 60, 80, 100, 120, 200) to avoid prime numbers, matching mango's behavior.
+        Defaults to True.
     :param extra_attrs: Additional global attributes to include.
     """
     if max_file_size_mb is not None:
@@ -109,6 +114,12 @@ def dataset_to_netcdf(
         slices_per_file = min(
             zdim, 1 + int((elements_per_file - 1) // elements_per_slice)
         )  # Matches mango `slicesPerFile` calculation
+
+        # Apply mango-compatible rounding to avoid prime numbers
+        if mango_compatible_slices_per_file_rounding and slices_per_file < zdim:
+            slices_per_file = _mango_round_slices_per_file(
+                slices_per_file, elements_per_file, elements_per_slice
+            )
 
         if zdim > slices_per_file:
             _write_split_netcdf(
@@ -334,3 +345,25 @@ def _numpy_to_netcdf_dtype(dtype: np.dtype) -> str:
         return _NUMPY_TO_NETCDF_DTYPE_MAP[dtype]
     except KeyError:
         raise ValueError(f"Unsupported dtype: {dtype}") from None
+
+
+_MANGO_DIVISORS = [2, 4, 6, 8, 12, 16, 24, 40, 60, 80, 100, 120, 200]
+
+
+def _mango_round_slices_per_file(
+    slices_per_file: int,
+    elements_per_file: int,
+    elements_per_slice: int,
+) -> int:
+    """Round slices_per_file to a value divisible by common factors.
+
+    This matches mango's logic to avoid prime numbers for better compression.
+    """
+    for divisor in _MANGO_DIVISORS:
+        # Round up to the next multiple of divisor
+        tmp_value = divisor * ((slices_per_file + divisor // 2) // divisor)
+        t = tmp_value * elements_per_slice
+        if abs(t - elements_per_file) / float(elements_per_file) < 0.08:
+            slices_per_file = tmp_value
+
+    return slices_per_file

--- a/tests/test_dataset_to_path.py
+++ b/tests/test_dataset_to_path.py
@@ -66,7 +66,7 @@ def test_to_path_with_split(_make_dataset):
         output_path = Path(tmpdir) / "tomo_split"
 
         # Use to_path with splitting
-        dataset.to_path(output_path, dataset_id="test_split", max_file_size_mb=0.05)
+        dataset.to_path(output_path, dataset_id="test_split", elements_per_file=1048)
 
         # Should have created directory
         dir_path = Path(str(output_path) + "_nc")
@@ -127,7 +127,7 @@ def test_to_path_split_with_nc_extension(_make_dataset):
         output_path = Path(tmpdir) / "tomo_output.nc"
 
         # Write with splitting
-        dataset.to_path(output_path, dataset_id="test_nc_split", max_file_size_mb=0.05)
+        dataset.to_path(output_path, dataset_id="test_nc_split", elements_per_file=1048)
 
         # Should have created directory with .nc replaced by _nc
         expected_dir = Path(tmpdir) / "tomo_output_nc"

--- a/tests/test_netcdf_write.py
+++ b/tests/test_netcdf_write.py
@@ -54,14 +54,14 @@ def test_write_split_netcdf(_make_dataset):
         # Use proper filename with datatype prefix
         output_path = Path(tmpdir) / "tomo_test_split"
 
-        # Write with max file size to force splitting
-        # Each z-slice is 20*30*2 bytes = 1200 bytes
-        # Set max to ~0.02 MB to get ~18 slices per file
+        # Write with small elements_per_file to force splitting
+        # Each z-slice has 20*30 = 600 elements
+        # elements_per_file=1000 gives ~1 slice per file (will split)
         anu_ctlab_io.netcdf.dataset_to_netcdf(
             dataset,
             output_path,
             dataset_id="test_split_dataset",
-            max_file_size_mb=0.02,
+            elements_per_file=1000,
         )
 
         # Check directory was created
@@ -125,7 +125,7 @@ def test_write_split_replaces_nc_extension(_make_dataset):
             dataset,
             output_path,
             dataset_id="test_nc_replacement",
-            max_file_size_mb=0.05,
+            elements_per_file=1000,
         )
 
         # Should have created directory with .nc replaced by _nc
@@ -211,24 +211,24 @@ def test_netcdf_history_roundtrip():
 def test_netcdf_default_split_behavior(_make_dataset):
     """Test that NetCDF defaults to split files for large datasets.
 
-    The default max_file_size_mb=500.0 should automatically split large datasets.
+    The default elements_per_file=256*1024*1024 should automatically split large datasets.
     """
-    # Create a "large" dataset that will trigger splitting (simulate 600MB)
-    # Note: We'll use small shape for test speed, but force split with small max_file_size_mb
+    # Create a "large" dataset that will trigger splitting
+    # Note: We'll use small shape for test speed, but force split with small elements_per_file
     test_shape = (100, 20, 30)
     dataset, data = _make_dataset(test_shape)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "tomo_default_split"
 
-        # Write with DEFAULT settings - should split due to small override for test
-        # Each z-slice is 20*30*2 = 1200 bytes = 0.0012 MB
-        # With default 500MB, wouldn't split, but we'll verify behavior with small size
+        # Write with small elements_per_file to force split in test
+        # Each z-slice has 20*30 = 600 elements
+        # elements_per_file=1000 gives ~1 slice per file
         anu_ctlab_io.netcdf.dataset_to_netcdf(
             dataset,
             output_path,
             dataset_id="test_default_split",
-            max_file_size_mb=0.01,  # Override to 0.01 MB to force split in test
+            elements_per_file=1000,  # Override to force split in test
         )
 
         # Check that split was created
@@ -237,7 +237,7 @@ def test_netcdf_default_split_behavior(_make_dataset):
 
         block_files = list(dir_path.glob("block*.nc"))
         assert len(block_files) > 1, (
-            "Should have multiple blocks with small max_file_size"
+            "Should have multiple blocks with small elements_per_file"
         )
 
         # Verify we can read it back
@@ -247,7 +247,7 @@ def test_netcdf_default_split_behavior(_make_dataset):
 
 
 def test_netcdf_single_file_option(_make_dataset):
-    """Test that max_file_size_mb=None forces single file output."""
+    """Test that elements_per_file=None forces single file output."""
     shape = (50, 20, 30)
     dataset, data = _make_dataset(shape)
 
@@ -259,7 +259,7 @@ def test_netcdf_single_file_option(_make_dataset):
             dataset,
             output_path,
             dataset_id="test_single_file",
-            max_file_size_mb=None,  # Force single file
+            elements_per_file=None,  # Force single file
         )
 
         # Should create single .nc file, not _nc directory
@@ -308,14 +308,14 @@ def test_netcdf_write_with_parallel_dask_config(_make_dataset):
             assert np.array_equal(read_single.data.compute(), data.compute())
 
             # Test split file write
-            # Each z-slice is 100*100*2 bytes = 20000 bytes = 0.02 MB
-            # Set max to 0.1 MB to get ~5 slices per file -> 10 files total
+            # Each z-slice has 100*100 = 10000 elements
+            # elements_per_file=50000 gives ~5 slices per file
             split_path = Path(tmpdir) / "tomo_parallel_split"
             anu_ctlab_io.netcdf.dataset_to_netcdf(
                 dataset,
                 split_path,
                 dataset_id="parallel_split_test",
-                max_file_size_mb=0.1,  # Force splitting into multiple blocks
+                elements_per_file=50000,  # Force splitting into multiple blocks
             )
 
             # Verify split files were written correctly


### PR DESCRIPTION
Recreates https://github.com/MaterialsPhysicsANU/mango/blob/3020516a4b41ad364a617b5a85763c56e15ea9b2/open/base/io/OutputFileHandler.hpp#L495-L512

We need matching block sizes to view data in `ncviewer`