### PR TITLE
feat: support aligned writing on NetCDF->Zarr path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add explicit and automatic Zarr chunk/shard layout selection through `chunks` and `shards`, including integer element targets, `"auto"` defaults, `None` to disable sharding, and `0` tuple entries to span an axis
 - Add `dimension_separator_threshold` parameter to `dataset_to_zarr()` to automatically use `"/"` as the chunk key encoding separator when the number of chunks exceeds the threshold (default 64), and `"."` otherwise
+- Add `input_aligned_chunks` parameter to `dataset_to_zarr()` to choose Zarr chunks/shards that align with the input dask chunk grid and avoid rechunking before writing
 - Allow opening of plain Zarr arrays with no `"mango"` attributes
   - The voxel size of such datasets is (1, 1, 1) with `VOXEL` units
 - Add `elements_per_file` and `mango_compatible_slices_per_file_rounding` parameter to `dataset_to_netcdf` matching the `mango` default

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "anu-ctlab-io[all]~=1.2.2",
     "typer>=0.24.1",
     "dask[distributed]>=2025.2.0",
+    "graphviz>=0.21",
 ]
 
 [project.optional-dependencies]

--- a/cli/src/anu_ctlab_io_cli/_cli.py
+++ b/cli/src/anu_ctlab_io_cli/_cli.py
@@ -73,6 +73,11 @@ def _validate_workers(workers: int) -> int:
     return workers
 
 
+def _visualize_dask_graph(result: Delayed, filename: Path) -> None:
+    result.visualize(filename=str(filename))
+    logger.info("Dask graph written to: %s", filename)
+
+
 def cli(
     input: Annotated[Path, typer.Argument(help="Input file path.")],
     output: Annotated[Path, typer.Argument(help="Output file path.")],
@@ -111,6 +116,13 @@ def cli(
             help="Number of local Dask workers/threads to use. Defaults to one per logical CPU.",
         ),
     ] = _default_workers(),
+    dask_graph: Annotated[
+        Path | None,
+        typer.Option(
+            "--dask-graph",
+            help="Write the Dask task graph visualization to this file before computing.",
+        ),
+    ] = None,
     voxel_size: Annotated[
         str | None,
         typer.Option(
@@ -184,6 +196,8 @@ def cli(
                         voxel_unit,
                     )
                     if result is not None:
+                        if dask_graph is not None:
+                            _visualize_dask_graph(result, dask_graph)
                         future = client.compute(result)
                         progress(future)
                         wait(future)
@@ -213,6 +227,8 @@ def cli(
                     voxel_unit,
                 )
                 if result is not None:
+                    if dask_graph is not None:
+                        _visualize_dask_graph(result, dask_graph)
                     if scheduler == Scheduler.synchronous:
                         result.compute(scheduler=scheduler.value)
                     else:

--- a/cli/src/anu_ctlab_io_cli/_cli.py
+++ b/cli/src/anu_ctlab_io_cli/_cli.py
@@ -1,6 +1,8 @@
 """CLI entry point for anu-ctlab-io."""
 
 import logging
+import os
+from contextlib import nullcontext
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
@@ -58,6 +60,19 @@ def _parse_voxel_size(value: str) -> tuple[float, float, float]:
         ) from e
 
 
+def _default_workers() -> int:
+    return os.cpu_count() or 1
+
+
+def _validate_workers(workers: int) -> int:
+    if workers < 1:
+        raise typer.BadParameter(
+            "Worker count must be at least 1.",
+            param_hint="--workers",
+        )
+    return workers
+
+
 def cli(
     input: Annotated[Path, typer.Argument(help="Input file path.")],
     output: Annotated[Path, typer.Argument(help="Output file path.")],
@@ -88,6 +103,14 @@ def cli(
             help="Dask scheduler to use.",
         ),
     ] = Scheduler.threads,
+    workers: Annotated[
+        int,
+        typer.Option(
+            "--workers",
+            "-j",
+            help="Number of local Dask workers/threads to use. Defaults to one per logical CPU.",
+        ),
+    ] = _default_workers(),
     voxel_size: Annotated[
         str | None,
         typer.Option(
@@ -112,6 +135,7 @@ def cli(
 ) -> None:
     """Convert between ANU CTLab array formats."""
     logging.getLogger().setLevel(log_level.upper())
+    workers = _validate_workers(workers)
     match scheduler:
         case Scheduler.distributed_mpi | Scheduler.distributed:
             if scheduler == Scheduler.distributed_mpi:
@@ -124,32 +148,59 @@ def cli(
                         param_hint="--scheduler",
                     ) from e
 
-                initialize()  # ranks 0 and 2+ block here as scheduler/workers; only rank 1 returns
-
-            from dask.distributed import Client, progress, wait
-
-            with Client() as client:
-                result = _convert(
-                    input,
-                    output,
-                    input_format,
-                    output_format,
-                    datatype,
-                    _parse_voxel_size(voxel_size) if voxel_size else None,
-                    voxel_unit,
+                logger.debug(
+                    "Dask scheduler: %s; workers are provided by MPI ranks; threads per worker: 1",
+                    scheduler.value,
                 )
-                if result is not None:
-                    future = client.compute(result)
-                    progress(future)
-                    wait(future)
-            if scheduler == Scheduler.distributed_mpi:
-                import os
+                initialize(
+                    nthreads=1
+                )  # ranks 0 and 2+ block here as scheduler/workers; only rank 1 returns
 
+            from dask.distributed import Client, LocalCluster, progress, wait
+
+            if scheduler == Scheduler.distributed:
+                logger.debug(
+                    "Dask scheduler: %s; workers: %s; threads per worker: 1",
+                    scheduler.value,
+                    workers,
+                )
+                cluster_context = LocalCluster(n_workers=workers, threads_per_worker=1)
+                client_or_address: Any = None
+            else:
+                cluster_context = nullcontext(None)
+                client_or_address = None
+
+            with cluster_context as cluster:
+                if cluster is not None:
+                    client_or_address = cluster
+                with Client(client_or_address) as client:
+                    result = _convert(
+                        input,
+                        output,
+                        input_format,
+                        output_format,
+                        datatype,
+                        _parse_voxel_size(voxel_size) if voxel_size else None,
+                        voxel_unit,
+                    )
+                    if result is not None:
+                        future = client.compute(result)
+                        progress(future)
+                        wait(future)
+            if scheduler == Scheduler.distributed_mpi:
                 os._exit(0)  # bypass atexit handlers to avoid dask-mpi hang on exit
         case Scheduler.synchronous | Scheduler.threads | Scheduler.processes:
             from dask.diagnostics import ProgressBar
 
             parsed_voxel_size = _parse_voxel_size(voxel_size) if voxel_size else None
+            if scheduler == Scheduler.synchronous:
+                logger.debug("Dask scheduler: %s; workers: 1", scheduler.value)
+            else:
+                logger.debug(
+                    "Dask scheduler: %s; workers: %s",
+                    scheduler.value,
+                    workers,
+                )
 
             with ProgressBar():
                 result = _convert(
@@ -162,7 +213,10 @@ def cli(
                     voxel_unit,
                 )
                 if result is not None:
-                    result.compute(scheduler=scheduler.value)
+                    if scheduler == Scheduler.synchronous:
+                        result.compute(scheduler=scheduler.value)
+                    else:
+                        result.compute(scheduler=scheduler.value, num_workers=workers)
 
 
 def _fmt_bytes(n: float) -> str:

--- a/cli/src/anu_ctlab_io_cli/_cli.py
+++ b/cli/src/anu_ctlab_io_cli/_cli.py
@@ -302,7 +302,7 @@ def _convert(
     _print_dataset_info(dataset)
     logger.info("Output: %s", output)
     kwargs: dict[str, Any] = {"filetype": output_format.value, "compute": False}
-    if _output_is_zarr(output, output_format):
+    if converting_netcdf_to_zarr:
         kwargs["input_aligned_chunks"] = True
     if datatype is not None:
         kwargs["datatype"] = datatype

--- a/cli/src/anu_ctlab_io_cli/_cli.py
+++ b/cli/src/anu_ctlab_io_cli/_cli.py
@@ -189,6 +189,19 @@ def _print_dataset_info(dataset) -> None:
     logger.info("  voxel size: (%s, %s, %s) %s", vz, vy, vx, dataset.voxel_unit)
 
 
+def _input_is_netcdf(path: Path, input_format: InputStorageFormat) -> bool:
+    return input_format == InputStorageFormat.netcdf or (
+        input_format == InputStorageFormat.auto
+        and (path.name.endswith(".nc") or path.name.endswith("_nc"))
+    )
+
+
+def _output_is_zarr(path: Path, output_format: OutputStorageFormat) -> bool:
+    return output_format == OutputStorageFormat.zarr or (
+        output_format == OutputStorageFormat.auto and path.name.endswith(".zarr")
+    )
+
+
 def _convert(
     input: Path,
     output: Path,
@@ -200,7 +213,14 @@ def _convert(
 ) -> Delayed | None:
     from anu_ctlab_io import Dataset
 
-    dataset = Dataset.from_path(input, filetype=input_format.value)
+    converting_netcdf_to_zarr = _input_is_netcdf(
+        input, input_format
+    ) and _output_is_zarr(output, output_format)
+    read_kwargs: dict[str, Any] = {}
+    if converting_netcdf_to_zarr:
+        read_kwargs["ignore_block_chunks"] = True
+
+    dataset = Dataset.from_path(input, filetype=input_format.value, **read_kwargs)
 
     # Apply voxel overrides if provided
     if voxel_size is not None:
@@ -212,9 +232,7 @@ def _convert(
     _print_dataset_info(dataset)
     logger.info("Output: %s", output)
     kwargs: dict[str, Any] = {"filetype": output_format.value, "compute": False}
-    if output_format == OutputStorageFormat.zarr or (
-        output_format == OutputStorageFormat.auto and output.name.endswith(".zarr")
-    ):
+    if _output_is_zarr(output, output_format):
         kwargs["input_aligned_chunks"] = True
     if datatype is not None:
         kwargs["datatype"] = datatype

--- a/cli/src/anu_ctlab_io_cli/_cli.py
+++ b/cli/src/anu_ctlab_io_cli/_cli.py
@@ -212,6 +212,10 @@ def _convert(
     _print_dataset_info(dataset)
     logger.info("Output: %s", output)
     kwargs: dict[str, Any] = {"filetype": output_format.value, "compute": False}
+    if output_format == OutputStorageFormat.zarr or (
+        output_format == OutputStorageFormat.auto and output.name.endswith(".zarr")
+    ):
+        kwargs["input_aligned_chunks"] = True
     if datatype is not None:
         kwargs["datatype"] = datatype
     try:

--- a/justfile
+++ b/justfile
@@ -6,6 +6,9 @@ docs:
 test:
     uvx --with tox-uv tox
 
+lint:
+    uvx pre-commit run --all-files
+
 bench:
     uv run --group bench --all-extras pytest benches/ -v
 

--- a/src/anu_ctlab_io/netcdf/__init__.py
+++ b/src/anu_ctlab_io/netcdf/__init__.py
@@ -29,7 +29,11 @@ __all__ = [
 
 
 def dataset_from_netcdf(
-    path: Path, *, parse_history: bool = True, **kwargs: Any
+    path: Path,
+    *,
+    parse_history: bool = True,
+    ignore_block_chunks: bool = False,
+    **kwargs: Any,
 ) -> Dataset:
     """Loads a :any:`Dataset` from the path to a netcdf.
 
@@ -37,10 +41,14 @@ def dataset_from_netcdf(
 
     :param Path: The path to the netcdf or directory of split netcdf blocks to be loaded.
     :param parse_history: Whether to parse the history of the netcdf file. Defaults to ``True``, but disableable because the parser is currently not guaranteed to succeed.
+    :param ignore_block_chunks: Ignore chunking stored inside NetCDF files and
+        treat each opened NetCDF file/block as one Dask chunk. Defaults to ``False``.
     :param kwargs: Currently this method consumes no kwargs, but will pass provided kwargs to ``Xarray.open_mfdataset``.
     :raises lark.exceptions.UnexpectedInput: Raised if ``parse_history=True`` and the parser fails to parse the specific history provided."""
     datatype = DataType.infer_from_path(path)
-    dataset = _read_netcdf(path, datatype, **kwargs)
+    dataset = _read_netcdf(
+        path, datatype, ignore_block_chunks=ignore_block_chunks, **kwargs
+    )
     dataset = dataset.rename(_transform_data_vars(dataset, datatype))
     dataset["data"] = dataset.data.astype(datatype.dtype)
     dataset.attrs = _update_attrs(dataset.attrs, parse_history)
@@ -87,8 +95,16 @@ def _update_attrs(attrs: dict[str, Any], parse_history_p: bool) -> dict[str, Any
     return new_attrs
 
 
-def _read_netcdf(path: Path | str, datatype: DataType, **kwargs: Any) -> xr.Dataset:
+def _read_netcdf(
+    path: Path | str,
+    datatype: DataType,
+    *,
+    ignore_block_chunks: bool = False,
+    **kwargs: Any,
+) -> xr.Dataset:
     path = os.path.normpath(os.path.expanduser(path))
+    kwargs.setdefault("chunks", -1 if ignore_block_chunks else {})
+
     if os.path.isdir(path):
         possible_files = [os.path.join(path, p) for p in os.listdir(path)]
         files = sorted(list(filter(os.path.isfile, possible_files)))
@@ -113,7 +129,6 @@ def _read_netcdf(path: Path | str, datatype: DataType, **kwargs: Any) -> xr.Data
             f"Could not read netCDF files in {path} with any available engine."
         ) from last_exc
     else:
-        chunks = kwargs.pop("chunks", -1)
         last_exc = None
         for engine in _read_engines():
             try:
@@ -121,7 +136,6 @@ def _read_netcdf(path: Path | str, datatype: DataType, **kwargs: Any) -> xr.Data
                     path,
                     engine=engine,
                     mask_and_scale=False,
-                    chunks=chunks,
                     **kwargs,
                 )
             except OSError as e:

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -21,12 +21,11 @@ from anu_ctlab_io._parse_history import History
 
 __all__ = ["OMEZarrVersion", "dataset_to_zarr"]
 
-_DEFAULT_CHUNK_ELEMENTS = max(256**2, 32**3)
-_DEFAULT_SHARD_ELEMENTS = max(8192**2, 512**3)
+_DEFAULT_CHUNK_ELEMENTS = max(8192**2, 512**3)
+_DEFAULT_SUBCHUNK_ELEMENTS = max(256**2, 32**3)
 
 type ChunkShape = tuple[int, ...]
 type ChunkSpec = ChunkShape | int | Literal["auto"]
-type ShardSpec = ChunkShape | int | Literal["auto"] | None
 
 
 class OMEZarrVersion(Enum):
@@ -47,7 +46,7 @@ def dataset_to_zarr(
     history: History | None = None,
     chunk_size_mb: float | None = None,  # TODO: 2.0.0 Remove this deprecated parameter
     chunks: ChunkSpec = "auto",
-    shards: ShardSpec = "auto",
+    shards: ChunkSpec | None = "auto",
     create_array_kwargs: dict[str, Any] | None = None,
     dimension_separator_threshold: int | None = 64,
     input_aligned_chunks: bool = False,
@@ -56,9 +55,11 @@ def dataset_to_zarr(
 ) -> Delayed | None:
     """Write a :any:`Dataset` to Zarr format.
 
-    By default, chunks and shards use power-of-two square or cubic shapes targeting
-    ``32**3`` and ``512**3`` elements respectively. Shapes are trimmed to the array
-    dimensions, and shards are rounded up to chunk multiples.
+    By default, sharded writes use power-of-two square or cubic shapes targeting
+    ``32**3`` elements for Zarr chunks and ``512**3`` elements for shards. Shapes
+    are trimmed to the array dimensions, and shards are rounded up to chunk
+    multiples. With ``shards=None``, ``chunks='auto'`` uses the larger unsharded
+    write target of ``512**3`` elements.
 
     :param dataset: The :any:`Dataset` to write.
     :param path: Path to write the Zarr store.
@@ -78,7 +79,8 @@ def dataset_to_zarr(
     :param chunks: Explicit chunk shape as a tuple shape (e.g., ``(10, 512, 512)``), int (target # of elements), or ``'auto'``.
         Can be provided on its own to write a non-sharded Zarr array, or together with ``shards`` to use the sharding codec.
         An integer specifies the target number of elements for an automatically derived layout.
-        ``'auto'`` uses a default target corresponding to ``32**3`` or ``256**2`` elements.
+        With sharding enabled, ``'auto'`` uses a default target corresponding to ``32**3`` or ``256**2`` elements.
+        With ``shards=None``, ``'auto'`` uses the larger unsharded target corresponding to ``512**3`` or ``8192**2`` elements.
         To write without sharding, pass ``shards=None`` explicitly.
         A value of ``0`` in a shape tuple means "span this axis" — the full array axis for unsharded writes, or the full shard axis when ``shards`` is also provided.
     :param shards: Explicit shard shape as a tuple shape (e.g., ``(100, 512, 512)``), int (target # of elements), or ``'auto'``.
@@ -138,10 +140,10 @@ def dataset_to_zarr(
     if isinstance(shards, tuple) and chunks == "auto" and not input_aligned_chunks:
         raise ValueError("shards cannot be provided without explicit chunks")
 
-    inner_chunks, outer_shards = _resolve_zarr_layout(
+    chunks, subchunks = _resolve_zarr_layout(
         shape=data_array.shape,
-        chunks=chunks,
-        shards=shards,
+        chunks=shards if shards is not None else chunks,
+        subchunks=chunks if shards is not None else None,
         aligned_chunks=data_array.chunks if input_aligned_chunks else None,
     )
 
@@ -153,11 +155,8 @@ def dataset_to_zarr(
 
     create_array_kwargs = dict(create_array_kwargs or {})
     if dimension_separator_threshold is not None:
-        # Use outer_shards for chunk key encoding calculation when sharding is
-        # enabled, since Zarr's chunk_key_encoding addresses shards, not inner chunks.
-        _key_chunks = outer_shards if outer_shards is not None else inner_chunks
         create_array_kwargs["chunk_key_encoding"] = _chunk_key_encoding(
-            data_array.shape, _key_chunks, dimension_separator_threshold
+            data_array.shape, chunks, dimension_separator_threshold
         )
 
     if ome_zarr_version is not None:
@@ -165,11 +164,11 @@ def dataset_to_zarr(
             data_array,
             path,
             dataset,
-            inner_chunks,
-            outer_shards,
-            create_array_kwargs,
-            mango_attrs,
-            ome_zarr_version,
+            chunks=chunks,
+            subchunks=subchunks,
+            create_array_kwargs=create_array_kwargs,
+            mango_attrs=mango_attrs,
+            ome_zarr_version=ome_zarr_version,
             rechunk_before_store=not input_aligned_chunks,
             compute=compute,
         )
@@ -178,10 +177,10 @@ def dataset_to_zarr(
             data_array,
             path,
             dataset,
-            inner_chunks,
-            outer_shards,
-            create_array_kwargs,
-            mango_attrs,
+            chunks=chunks,
+            subchunks=subchunks,
+            create_array_kwargs=create_array_kwargs,
+            mango_attrs=mango_attrs,
             rechunk_before_store=not input_aligned_chunks,
             compute=compute,
         )
@@ -212,51 +211,81 @@ def _resolve_zarr_layout(
     *,
     shape: ChunkShape,
     chunks: ChunkSpec,
-    shards: ShardSpec,
+    subchunks: ChunkSpec | None,
     aligned_chunks: tuple[tuple[int, ...], ...] | None = None,
 ) -> tuple[ChunkShape, ChunkShape | None]:
-    """Resolve the final Zarr chunk/shard layout from the supported writer inputs.
+    """Resolve the internal Zarr chunks/subchunks layout.
 
-    The resolution order is:
-    - explicit ``chunks``/``shards`` shapes when provided
-    - integer element targets and ``'auto'`` sentinels, which derive power-of-two
-      square or cubic layouts
+    This helper uses the writer's internal naming, not the public
+    ``dataset_to_zarr`` parameter names. Before this function is called,
+    public arguments are adapted as follows:
 
-    Explicit shapes also support ``0`` as a sentinel. In ``chunks``, ``0`` means span
-    the full array axis for unsharded writes, or the full shard axis when ``shards`` is
-    provided. In ``shards``, ``0`` means span the array axis, rounded up to a multiple
-    of the resolved chunk size so the sharding codec remains valid.
+    - ``shards is None``: ``chunks`` is the public ``chunks`` value and
+      ``subchunks`` is ``None``.
+    - ``shards is not None``: ``chunks`` is the public ``shards`` value and
+      ``subchunks`` is the public ``chunks`` value.
 
-    When ``aligned_chunks`` is provided, layout selection is constrained to that
-    existing chunk grid and no writer rechunking is required. The grid must be
-    regular except for smaller final edge chunks. For sharded writes, resolved
-    shards must evenly divide the aligned chunk shape and resolved inner chunks
-    must evenly divide the shard shape, allowing multiple shards and/or inner chunks
-    per aligned chunk. For unsharded writes, resolved chunks must evenly divide the
-    aligned chunk shape. ``shards='auto'`` uses the full aligned chunk shape.
-    Unsharded ``chunks='auto'`` also uses the full aligned chunk shape because chunks
-    are the write unit. Sharded ``chunks='auto'`` still derives inner chunks from the
-    default chunk element target, then chooses the largest derived shape that evenly
-    divides the resolved shard shape.
+    The return value follows the same internal naming. ``chunks`` is the outer
+    write shape. ``subchunks`` is ``None`` for unsharded writes, or the inner
+    Zarr chunk shape stored inside each sharded chunk.
+
+    Without ``aligned_chunks``:
+
+    - Unsharded ``chunks='auto'`` uses ``_DEFAULT_CHUNK_ELEMENTS`` and is
+      trimmed to the array shape.
+    - Sharded ``chunks='auto'`` uses ``_DEFAULT_CHUNK_ELEMENTS`` for the outer
+      sharded chunk; ``subchunks='auto'`` uses ``_DEFAULT_SUBCHUNK_ELEMENTS``
+      for the inner Zarr chunks.
+    - Integer specs are element targets. Inner subchunks are derived as a
+      power-of-two square/cubic shape trimmed to the array shape. Outer chunks
+      are derived the same way, then rounded up to a multiple of the resolved
+      subchunk shape so the sharding codec can store them.
+    - Tuple specs are explicit shapes. A zero in unsharded ``chunks`` spans the
+      full array axis. A zero in sharded ``chunks`` spans the full array axis,
+      rounded up to a subchunk multiple. A zero in ``subchunks`` spans the
+      corresponding resolved outer chunk axis.
+
+    With ``aligned_chunks``, no writer rechunking is required. The aligned grid
+    must be regular except for smaller final edge chunks. Unsharded chunks must
+    evenly divide the aligned chunk shape. Sharded outer chunks must evenly
+    divide the aligned chunk shape, and subchunks must evenly divide the outer
+    chunk shape. Tuple zeros span the aligned chunk shape for ``chunks`` and the
+    resolved outer chunk shape for ``subchunks``. Integer and ``'auto'`` specs
+    choose the largest divisor of the containing shape that does not exceed the
+    corresponding automatic target.
     """
     if aligned_chunks is not None:
         return _resolve_input_aligned_zarr_layout(
             shape=shape,
             aligned_chunks=aligned_chunks,
             chunks=chunks,
-            shards=shards,
+            subchunks=subchunks,
         )
+
+    if subchunks is None:
+        if chunks == "auto":
+            chunks = _DEFAULT_CHUNK_ELEMENTS
+        if isinstance(chunks, int):
+            chunks = _auto_shape(shape, chunks)
+
+        resolved_chunks, _ = _normalize_explicit_shapes(
+            shape, chunks=chunks, subchunks=None
+        )
+        return resolved_chunks, None
 
     if chunks == "auto":
         chunks = _DEFAULT_CHUNK_ELEMENTS
+    if subchunks == "auto":
+        subchunks = _DEFAULT_SUBCHUNK_ELEMENTS
+    if isinstance(subchunks, int):
+        subchunks = _auto_shape(shape, subchunks)
     if isinstance(chunks, int):
-        chunks = _auto_shape(shape, chunks)
-    if shards == "auto":
-        shards = _DEFAULT_SHARD_ELEMENTS
-    if isinstance(shards, int):
-        shards = _auto_shards(shape, chunks, shards)
+        chunks = _auto_shards(shape, subchunks, chunks)
 
-    return _normalize_explicit_shapes(shape, chunks, shards)
+    resolved_chunks, resolved_subchunks = _normalize_explicit_shapes(
+        shape, chunks=chunks, subchunks=subchunks
+    )
+    return resolved_chunks, resolved_subchunks
 
 
 def _resolve_input_aligned_zarr_layout(
@@ -264,11 +293,11 @@ def _resolve_input_aligned_zarr_layout(
     shape: ChunkShape,
     aligned_chunks: tuple[tuple[int, ...], ...],
     chunks: ChunkSpec,
-    shards: ShardSpec,
+    subchunks: ChunkSpec | None,
 ) -> tuple[ChunkShape, ChunkShape | None]:
     aligned_chunk_shape = _regular_aligned_chunk_shape(aligned_chunks)
 
-    if shards is None:
+    if subchunks is None:
         if chunks == "auto":
             resolved_chunks = aligned_chunk_shape
         elif isinstance(chunks, tuple):
@@ -282,23 +311,23 @@ def _resolve_input_aligned_zarr_layout(
         _validate_aligned_write_shape(aligned_chunk_shape, resolved_chunks)
         return resolved_chunks, None
 
-    if shards == "auto":
-        resolved_shards = aligned_chunk_shape
-    elif isinstance(shards, tuple):
-        resolved_shards = _normalize_input_aligned_tuple(shards, aligned_chunk_shape)
+    if chunks == "auto":
+        resolved_chunks = aligned_chunk_shape
+    elif isinstance(chunks, tuple):
+        resolved_chunks = _normalize_input_aligned_tuple(chunks, aligned_chunk_shape)
     else:
-        resolved_shards = _input_aligned_subchunk_shape(
-            shape, aligned_chunk_shape, shards
+        resolved_chunks = _input_aligned_subchunk_shape(
+            shape, aligned_chunk_shape, chunks
         )
-    _validate_aligned_write_shape(aligned_chunk_shape, resolved_shards)
+    _validate_aligned_write_shape(aligned_chunk_shape, resolved_chunks)
 
-    resolved_chunks = (
-        _normalize_input_aligned_tuple(chunks, resolved_shards)
-        if isinstance(chunks, tuple)
-        else _input_aligned_subchunk_shape(shape, resolved_shards, chunks)
+    resolved_subchunks = (
+        _normalize_input_aligned_tuple(subchunks, resolved_chunks)
+        if isinstance(subchunks, tuple)
+        else _input_aligned_subchunk_shape(shape, resolved_chunks, subchunks)
     )
-    _validate_subchunks_divide_write_shape(resolved_chunks, resolved_shards)
-    return resolved_chunks, resolved_shards
+    _validate_subchunks_divide_write_shape(resolved_subchunks, resolved_chunks)
+    return resolved_chunks, resolved_subchunks
 
 
 def _regular_aligned_chunk_shape(
@@ -352,7 +381,7 @@ def _input_aligned_subchunk_shape(
     chunks: ChunkSpec,
 ) -> ChunkShape:
     if chunks == "auto":
-        chunks = _DEFAULT_CHUNK_ELEMENTS
+        chunks = _DEFAULT_SUBCHUNK_ELEMENTS
     if isinstance(chunks, int):
         target = _auto_shape(shape, chunks)
         return tuple(
@@ -402,48 +431,45 @@ def _validate_subchunks_divide_write_shape(
 def _normalize_explicit_shapes(
     shape: ChunkShape,
     chunks: ChunkShape,
-    shards: ChunkShape | None,
+    subchunks: ChunkShape | None,
 ) -> tuple[ChunkShape, ChunkShape | None]:
     """Validate explicit layout shapes and expand any zero-valued span sentinels.
 
-    A zero chunk size spans the corresponding shard axis when sharding is enabled,
-    otherwise it spans the full array axis. A zero shard size spans the array axis,
-    rounded up to a chunk multiple so zarr's sharding codec accepts the layout.
+    A zero in unsharded ``chunks`` spans the full array axis. A zero in sharded
+    ``chunks`` spans the full array axis, rounded up to a subchunk multiple. A
+    zero in ``subchunks`` spans the corresponding resolved chunk axis.
     """
     if len(chunks) != len(shape):
         raise ValueError(
             f"chunks must have the same number of dimensions as the array shape. Got chunks={chunks}, shape={shape}."
         )
-    if shards is not None and len(shards) != len(shape):
+    if subchunks is not None and len(subchunks) != len(shape):
         raise ValueError(
-            f"shards must have the same number of dimensions as the array shape. Got shards={shards}, shape={shape}."
+            f"subchunks must have the same number of dimensions as the array shape. Got subchunks={subchunks}, shape={shape}."
         )
 
-    chunk_span = (
-        tuple(
-            axis_size if shard_size == 0 else shard_size
-            for shard_size, axis_size in zip(shards, shape, strict=True)
-        )
-        if shards is not None
-        else shape
-    )
-    resolved_chunks = tuple(
-        axis_size if chunk_size == 0 else chunk_size
-        for chunk_size, axis_size in zip(chunks, chunk_span, strict=True)
-    )
+    resolved_chunks_list: list[int] = []
+    for axis_size, chunk_size, subchunk_size in zip(
+        shape, chunks, subchunks or (0,) * len(shape), strict=True
+    ):
+        if chunk_size != 0:
+            resolved_chunks_list.append(chunk_size)
+        elif subchunks is None or subchunk_size == 0:
+            resolved_chunks_list.append(axis_size)
+        else:
+            resolved_chunks_list.append(_round_up_to_multiple(axis_size, subchunk_size))
+    resolved_chunks = tuple(resolved_chunks_list)
 
-    resolved_shards: ChunkShape | None = None
-    if shards is not None:
-        resolved_shards = tuple(
-            _round_up_to_multiple(axis_size, chunk_size)
-            if shard_size == 0
-            else shard_size
-            for shard_size, axis_size, chunk_size in zip(
-                shards, shape, resolved_chunks, strict=True
+    resolved_subchunks: ChunkShape | None = None
+    if subchunks is not None:
+        resolved_subchunks = tuple(
+            chunk_size if subchunk_size == 0 else subchunk_size
+            for subchunk_size, chunk_size in zip(
+                subchunks, resolved_chunks, strict=True
             )
         )
 
-    return resolved_chunks, resolved_shards
+    return resolved_chunks, resolved_subchunks
 
 
 def _power_of_two_edge(elements: int, dimensions: int) -> int:
@@ -476,7 +502,7 @@ def _auto_shards(
     chunks: ChunkShape,
     elements: int,
 ) -> ChunkShape:
-    """Return auto shard dimensions trimmed to the array and aligned to chunks."""
+    """Return auto outer dimensions trimmed to the array and aligned to chunks."""
     target = _auto_shape(shape, elements)
     return tuple(
         shard_size
@@ -523,8 +549,9 @@ def _write_ome_zarr_group(
     data_array: da.Array,
     path: Path,
     dataset: Dataset,
-    inner_chunks: ChunkShape,
-    outer_shards: ChunkShape | None,
+    *,
+    chunks: ChunkShape,
+    subchunks: ChunkShape | None,
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
     ome_zarr_version: OMEZarrVersion,
@@ -534,10 +561,10 @@ def _write_ome_zarr_group(
     """Write data as an OME-Zarr group, optionally using Zarr v3 sharding.
 
     In Zarr v3 sharding:
-    - inner_chunks (chunks param) = subdivisions within each shard file
-    - outer_shards (shards param) = how data is split into shard files
+    - chunks = primary write chunks
+    - subchunks = subdivisions within each sharded chunk
 
-    If ``outer_shards`` is ``None``, the array is written without the sharding codec.
+    If ``subchunks`` is ``None``, the array is written without the sharding codec.
     """
 
     if not str(path).endswith(".zarr"):
@@ -585,8 +612,8 @@ def _write_ome_zarr_group(
     array = root.create_array(
         "0",
         shape=data_array.shape,
-        chunks=inner_chunks,
-        shards=outer_shards,
+        chunks=subchunks or chunks,
+        shards=chunks if subchunks is not None else None,
         dtype=data_array.dtype,
         dimension_names=list(dimension_names),
         overwrite=True,
@@ -615,8 +642,9 @@ def _write_zarr_array(
     data_array: da.Array,
     path: Path,
     dataset: Dataset,
-    inner_chunks: ChunkShape,
-    outer_shards: ChunkShape | None,
+    *,
+    chunks: ChunkShape,
+    subchunks: ChunkShape | None,
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
     rechunk_before_store: bool,
@@ -624,9 +652,9 @@ def _write_zarr_array(
 ) -> Delayed | None:
     """Write data as a simple Zarr V3 array with mango metadata.
 
-    When ``outer_shards`` is provided, Zarr v3 sharding is used:
-    - inner_chunks (chunks param) = subdivisions within each shard file
-    - outer_shards (shards param) = how data is split into shard files
+    When ``subchunks`` is provided, Zarr v3 sharding is used:
+    - chunks = primary write chunks
+    - subchunks = subdivisions within each sharded chunk
     """
     if not str(path).endswith(".zarr"):
         path = Path(str(path) + ".zarr")
@@ -642,8 +670,8 @@ def _write_zarr_array(
     array = zarr.create_array(
         path,
         shape=data_array.shape,
-        chunks=inner_chunks,
-        shards=outer_shards,
+        chunks=subchunks or chunks,
+        shards=chunks if subchunks is not None else None,
         dtype=data_array.dtype,
         dimension_names=list(dimension_names),
         overwrite=True,

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -1,5 +1,6 @@
 """Write data to the ANU CTLab zarr data format."""
 
+import logging
 import warnings
 from datetime import datetime
 from enum import Enum
@@ -20,6 +21,8 @@ from anu_ctlab_io._datatype import DataType
 from anu_ctlab_io._parse_history import History
 
 __all__ = ["OMEZarrVersion", "dataset_to_zarr"]
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_CHUNK_ELEMENTS = max(8192**2, 512**3)
 _DEFAULT_SUBCHUNK_ELEMENTS = max(256**2, 32**3)
@@ -106,6 +109,24 @@ def dataset_to_zarr(
     if isinstance(path, str):
         path = Path(path)
 
+    logger.debug(
+        "Writing dataset to Zarr: path=%s, datatype=%s, dataset_id=%s, "
+        "ome_zarr_version=%s, chunks=%s, shards=%s, input_aligned_chunks=%s, "
+        "dimension_separator_threshold=%s, compute=%s, create_array_kwargs=%s, "
+        "extra_attrs=%s",
+        path,
+        datatype,
+        dataset_id,
+        ome_zarr_version,
+        chunks,
+        shards,
+        input_aligned_chunks,
+        dimension_separator_threshold,
+        compute,
+        create_array_kwargs,
+        sorted(extra_attrs),
+    )
+
     if datatype is None:
         if dataset._datatype is not None:
             datatype = dataset._datatype
@@ -120,6 +141,14 @@ def dataset_to_zarr(
         dataset_id = f"{timestamp}_{datatype}"
 
     data_array = dataset.data
+    logger.debug(
+        "Input dask array: shape=%s, dtype=%s, chunks=%s, chunksize=%s, npartitions=%s",
+        data_array.shape,
+        data_array.dtype,
+        data_array.chunks,
+        data_array.chunksize,
+        data_array.npartitions,
+    )
 
     ignored_size_args = ", ".join(
         name
@@ -146,6 +175,12 @@ def dataset_to_zarr(
         subchunks=chunks if shards is not None else None,
         aligned_chunks=data_array.chunks if input_aligned_chunks else None,
     )
+    logger.debug(
+        "Resolved Zarr layout: chunks=%s, subchunks=%s, rechunk_before_store=%s",
+        chunks,
+        subchunks,
+        not input_aligned_chunks,
+    )
 
     mango_attrs: dict[str, Any] | None = None
     if datatype is not None:
@@ -158,8 +193,14 @@ def dataset_to_zarr(
         create_array_kwargs["chunk_key_encoding"] = _chunk_key_encoding(
             data_array.shape, chunks, dimension_separator_threshold
         )
+        logger.debug(
+            "Selected chunk key encoding: key_chunks=%s, encoding=%s",
+            chunks,
+            create_array_kwargs["chunk_key_encoding"],
+        )
 
     if ome_zarr_version is not None:
+        logger.debug("Writing OME-Zarr group with version %s", ome_zarr_version)
         return _write_ome_zarr_group(
             data_array,
             path,
@@ -173,6 +214,7 @@ def dataset_to_zarr(
             compute=compute,
         )
     else:
+        logger.debug("Writing plain Zarr array")
         return _write_zarr_array(
             data_array,
             path,
@@ -619,6 +661,16 @@ def _write_ome_zarr_group(
         overwrite=True,
         **create_array_kwargs,
     )
+    logger.debug(
+        "Created OME-Zarr array: path=%s, shape=%s, dtype=%s, chunks=%s, shards=%s, "
+        "dimension_names=%s",
+        path,
+        array.shape,
+        array.dtype,
+        array.chunks,
+        array.shards,
+        dimension_names,
+    )
 
     # Always rechunk to the write granularity of the Zarr array before writing.
     # If using sharding, the write granularity is the shard shape (`.shards`).
@@ -627,7 +679,17 @@ def _write_ome_zarr_group(
     # The straddling chunks/shards w.r.t the array shape need no special handling.
     if rechunk_before_store:
         write_shape = array.shards or array.chunks
+        logger.debug(
+            "Rechunking input for OME-Zarr write: source_chunks=%s, write_shape=%s",
+            data_array.chunks,
+            write_shape,
+        )
         data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
+    else:
+        logger.debug(
+            "Skipping input rechunk for OME-Zarr write: source_chunks=%s",
+            data_array.chunks,
+        )
 
     # dask's to_zarr internally calls normalize_chunks("auto", ...) which can produce
     # chunk sizes that are not multiples of the shard shape, causing misaligned writes
@@ -677,6 +739,16 @@ def _write_zarr_array(
         overwrite=True,
         **create_array_kwargs,
     )
+    logger.debug(
+        "Created Zarr array: path=%s, shape=%s, dtype=%s, chunks=%s, shards=%s, "
+        "dimension_names=%s",
+        path,
+        array.shape,
+        array.dtype,
+        array.chunks,
+        array.shards,
+        dimension_names,
+    )
 
     if mango_attrs:
         array.attrs["mango"] = mango_attrs
@@ -685,7 +757,17 @@ def _write_zarr_array(
     # See comment in _write_ome_zarr_group for explanation.
     if rechunk_before_store:
         write_shape = array.shards or array.chunks
+        logger.debug(
+            "Rechunking input for Zarr write: source_chunks=%s, write_shape=%s",
+            data_array.chunks,
+            write_shape,
+        )
         data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
+    else:
+        logger.debug(
+            "Skipping input rechunk for Zarr write: source_chunks=%s",
+            data_array.chunks,
+        )
 
     result: Delayed | None = da.store(data_array, array, lock=False, compute=compute)  # type: ignore[arg-type]
     return result

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -50,6 +50,7 @@ def dataset_to_zarr(
     shards: ShardSpec = "auto",
     create_array_kwargs: dict[str, Any] | None = None,
     dimension_separator_threshold: int | None = 64,
+    input_aligned_chunks: bool = False,
     compute: bool = True,
     **extra_attrs: Any,
 ) -> Delayed | None:
@@ -92,6 +93,10 @@ def dataset_to_zarr(
     :param dimension_separator_threshold: Use ``'/'`` as the chunk key dimension
         separator when the number of chunks exceeds this threshold; otherwise use
         ``'.'``. ``None`` uses the Zarr default of ``'/'``.
+    :param input_aligned_chunks: Choose Zarr chunks/shards aligned to the input dask
+        chunk grid and skip rechunking before storing. With sharding is enabled, shards
+        are aligned to the dask chunks and inner chunks evenly divide each shard.
+        With ``shards=None``, chunks are aligned to the dask chunks.
     :param compute: If ``True`` (default), compute immediately. If ``False``, return
         a :any:`dask.delayed.Delayed` for deferred execution.
     :param extra_attrs: Additional attributes to include in mango metadata.
@@ -130,13 +135,14 @@ def dataset_to_zarr(
             stacklevel=2,
         )
 
-    if isinstance(shards, tuple) and chunks == "auto":
+    if isinstance(shards, tuple) and chunks == "auto" and not input_aligned_chunks:
         raise ValueError("shards cannot be provided without explicit chunks")
 
     inner_chunks, outer_shards = _resolve_zarr_layout(
         shape=data_array.shape,
         chunks=chunks,
         shards=shards,
+        aligned_chunks=data_array.chunks if input_aligned_chunks else None,
     )
 
     mango_attrs: dict[str, Any] | None = None
@@ -164,7 +170,8 @@ def dataset_to_zarr(
             create_array_kwargs,
             mango_attrs,
             ome_zarr_version,
-            compute,
+            rechunk_before_store=not input_aligned_chunks,
+            compute=compute,
         )
     else:
         return _write_zarr_array(
@@ -175,7 +182,8 @@ def dataset_to_zarr(
             outer_shards,
             create_array_kwargs,
             mango_attrs,
-            compute,
+            rechunk_before_store=not input_aligned_chunks,
+            compute=compute,
         )
 
 
@@ -205,6 +213,7 @@ def _resolve_zarr_layout(
     shape: ChunkShape,
     chunks: ChunkSpec,
     shards: ShardSpec,
+    aligned_chunks: tuple[tuple[int, ...], ...] | None = None,
 ) -> tuple[ChunkShape, ChunkShape | None]:
     """Resolve the final Zarr chunk/shard layout from the supported writer inputs.
 
@@ -217,7 +226,27 @@ def _resolve_zarr_layout(
     the full array axis for unsharded writes, or the full shard axis when ``shards`` is
     provided. In ``shards``, ``0`` means span the array axis, rounded up to a multiple
     of the resolved chunk size so the sharding codec remains valid.
+
+    When ``aligned_chunks`` is provided, layout selection is constrained to that
+    existing chunk grid and no writer rechunking is required. The grid must be
+    regular except for smaller final edge chunks. For sharded writes, resolved
+    shards must evenly divide the aligned chunk shape and resolved inner chunks
+    must evenly divide the shard shape, allowing multiple shards and/or inner chunks
+    per aligned chunk. For unsharded writes, resolved chunks must evenly divide the
+    aligned chunk shape. ``shards='auto'`` uses the full aligned chunk shape.
+    Unsharded ``chunks='auto'`` also uses the full aligned chunk shape because chunks
+    are the write unit. Sharded ``chunks='auto'`` still derives inner chunks from the
+    default chunk element target, then chooses the largest derived shape that evenly
+    divides the resolved shard shape.
     """
+    if aligned_chunks is not None:
+        return _resolve_input_aligned_zarr_layout(
+            shape=shape,
+            aligned_chunks=aligned_chunks,
+            chunks=chunks,
+            shards=shards,
+        )
+
     if chunks == "auto":
         chunks = _DEFAULT_CHUNK_ELEMENTS
     if isinstance(chunks, int):
@@ -228,6 +257,146 @@ def _resolve_zarr_layout(
         shards = _auto_shards(shape, chunks, shards)
 
     return _normalize_explicit_shapes(shape, chunks, shards)
+
+
+def _resolve_input_aligned_zarr_layout(
+    *,
+    shape: ChunkShape,
+    aligned_chunks: tuple[tuple[int, ...], ...],
+    chunks: ChunkSpec,
+    shards: ShardSpec,
+) -> tuple[ChunkShape, ChunkShape | None]:
+    aligned_chunk_shape = _regular_aligned_chunk_shape(aligned_chunks)
+
+    if shards is None:
+        if chunks == "auto":
+            resolved_chunks = aligned_chunk_shape
+        elif isinstance(chunks, tuple):
+            resolved_chunks = _normalize_input_aligned_tuple(
+                chunks, aligned_chunk_shape
+            )
+        else:
+            resolved_chunks = _input_aligned_subchunk_shape(
+                shape, aligned_chunk_shape, chunks
+            )
+        _validate_aligned_write_shape(aligned_chunk_shape, resolved_chunks)
+        return resolved_chunks, None
+
+    if shards == "auto":
+        resolved_shards = aligned_chunk_shape
+    elif isinstance(shards, tuple):
+        resolved_shards = _normalize_input_aligned_tuple(shards, aligned_chunk_shape)
+    else:
+        resolved_shards = _input_aligned_subchunk_shape(
+            shape, aligned_chunk_shape, shards
+        )
+    _validate_aligned_write_shape(aligned_chunk_shape, resolved_shards)
+
+    resolved_chunks = (
+        _normalize_input_aligned_tuple(chunks, resolved_shards)
+        if isinstance(chunks, tuple)
+        else _input_aligned_subchunk_shape(shape, resolved_shards, chunks)
+    )
+    _validate_subchunks_divide_write_shape(resolved_chunks, resolved_shards)
+    return resolved_chunks, resolved_shards
+
+
+def _regular_aligned_chunk_shape(
+    aligned_chunks: tuple[tuple[int, ...], ...],
+) -> ChunkShape:
+    regular_chunks: list[int] = []
+    for axis, axis_chunks in enumerate(aligned_chunks):
+        if len(axis_chunks) == 0:
+            raise ValueError("input_aligned_chunks requires non-empty aligned chunks")
+
+        regular_chunk = int(axis_chunks[0])
+        if regular_chunk <= 0:
+            raise ValueError("input_aligned_chunks requires positive aligned chunks")
+
+        internal_chunks = axis_chunks[:-1] if len(axis_chunks) > 1 else axis_chunks
+        if any(int(chunk) != regular_chunk for chunk in internal_chunks):
+            raise ValueError(
+                "input_aligned_chunks requires regular aligned chunks; "
+                f"axis {axis} has chunks {axis_chunks}."
+            )
+        if int(axis_chunks[-1]) > regular_chunk:
+            raise ValueError(
+                "input_aligned_chunks requires regular aligned chunks; "
+                f"axis {axis} has chunks {axis_chunks}."
+            )
+        regular_chunks.append(regular_chunk)
+
+    return tuple(regular_chunks)
+
+
+def _normalize_input_aligned_tuple(
+    spec: ChunkShape,
+    span: ChunkShape,
+) -> ChunkShape:
+    if len(spec) != len(span):
+        raise ValueError(
+            f"input-aligned layout must have {len(span)} dimensions. Got {spec}."
+        )
+    resolved = tuple(
+        span_size if size == 0 else size
+        for size, span_size in zip(spec, span, strict=True)
+    )
+    if any(size <= 0 for size in resolved):
+        raise ValueError(f"input-aligned layout sizes must be positive. Got {spec}.")
+    return resolved
+
+
+def _input_aligned_subchunk_shape(
+    shape: ChunkShape,
+    write_shape: ChunkShape,
+    chunks: ChunkSpec,
+) -> ChunkShape:
+    if chunks == "auto":
+        chunks = _DEFAULT_CHUNK_ELEMENTS
+    if isinstance(chunks, int):
+        target = _auto_shape(shape, chunks)
+        return tuple(
+            _largest_divisor_at_most(write_size, target_size)
+            for write_size, target_size in zip(write_shape, target, strict=True)
+        )
+    assert isinstance(chunks, tuple)
+    return chunks
+
+
+def _largest_divisor_at_most(value: int, limit: int) -> int:
+    limit = min(value, limit)
+    for candidate in range(limit, 0, -1):
+        if value % candidate == 0:
+            return candidate
+    raise ValueError(f"Could not find a positive divisor for {value}.")
+
+
+def _validate_aligned_write_shape(
+    aligned_chunk_shape: ChunkShape,
+    write_shape: ChunkShape,
+) -> None:
+    _validate_subchunks_divide_write_shape(write_shape, aligned_chunk_shape)
+
+
+def _validate_subchunks_divide_write_shape(
+    subchunks: ChunkShape,
+    write_shape: ChunkShape,
+) -> None:
+    if len(subchunks) != len(write_shape):
+        raise ValueError(
+            "subchunks must have the same dimensions as the write shape. "
+            f"Got {subchunks} and {write_shape}."
+        )
+    for axis, (subchunk, write_size) in enumerate(
+        zip(subchunks, write_shape, strict=True)
+    ):
+        if subchunk <= 0:
+            raise ValueError(f"subchunk sizes must be positive. Got {subchunks}.")
+        if write_size % subchunk != 0:
+            raise ValueError(
+                "input_aligned_chunks requires subchunks to evenly divide the "
+                f"write shape. Axis {axis}: {subchunk} does not divide {write_size}."
+            )
 
 
 def _normalize_explicit_shapes(
@@ -359,6 +528,7 @@ def _write_ome_zarr_group(
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
     ome_zarr_version: OMEZarrVersion,
+    rechunk_before_store: bool,
     compute: bool = True,
 ) -> Delayed | None:
     """Write data as an OME-Zarr group, optionally using Zarr v3 sharding.
@@ -428,8 +598,9 @@ def _write_ome_zarr_group(
     # If not using sharding, `.shards` is None and `chunks` is used as the write granularity.
     # Note that the rechunk is lazy if the array is already in the desired chunk shape.
     # The straddling chunks/shards w.r.t the array shape need no special handling.
-    write_shape = array.shards or array.chunks
-    data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
+    if rechunk_before_store:
+        write_shape = array.shards or array.chunks
+        data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
 
     # dask's to_zarr internally calls normalize_chunks("auto", ...) which can produce
     # chunk sizes that are not multiples of the shard shape, causing misaligned writes
@@ -448,6 +619,7 @@ def _write_zarr_array(
     outer_shards: ChunkShape | None,
     create_array_kwargs: dict[str, Any],
     mango_attrs: dict[str, Any] | None,
+    rechunk_before_store: bool,
     compute: bool = True,
 ) -> Delayed | None:
     """Write data as a simple Zarr V3 array with mango metadata.
@@ -483,8 +655,9 @@ def _write_zarr_array(
 
     # Always rechunk to the write granularity of the Zarr array before writing.
     # See comment in _write_ome_zarr_group for explanation.
-    write_shape = array.shards or array.chunks
-    data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
+    if rechunk_before_store:
+        write_shape = array.shards or array.chunks
+        data_array = data_array.rechunk(write_shape)  # type: ignore[no-untyped-call]
 
     result: Delayed | None = da.store(data_array, array, lock=False, compute=compute)  # type: ignore[arg-type]
     return result

--- a/src/anu_ctlab_io/zarr/_writer.py
+++ b/src/anu_ctlab_io/zarr/_writer.py
@@ -338,6 +338,7 @@ def _resolve_input_aligned_zarr_layout(
     subchunks: ChunkSpec | None,
 ) -> tuple[ChunkShape, ChunkShape | None]:
     aligned_chunk_shape = _regular_aligned_chunk_shape(aligned_chunks)
+    axis_spans_array = _aligned_chunk_axes_span_array(shape, aligned_chunks)
 
     if subchunks is None:
         if chunks == "auto":
@@ -354,14 +355,21 @@ def _resolve_input_aligned_zarr_layout(
         return resolved_chunks, None
 
     if chunks == "auto":
-        resolved_chunks = aligned_chunk_shape
+        resolved_chunks = _input_aligned_chunk_shape(
+            shape=shape,
+            aligned_chunk_shape=aligned_chunk_shape,
+            axis_spans_array=axis_spans_array,
+            subchunks=subchunks,
+        )
     elif isinstance(chunks, tuple):
         resolved_chunks = _normalize_input_aligned_tuple(chunks, aligned_chunk_shape)
     else:
         resolved_chunks = _input_aligned_subchunk_shape(
             shape, aligned_chunk_shape, chunks
         )
-    _validate_aligned_write_shape(aligned_chunk_shape, resolved_chunks)
+    _validate_aligned_write_shape(
+        aligned_chunk_shape, resolved_chunks, axis_spans_array=axis_spans_array
+    )
 
     resolved_subchunks = (
         _normalize_input_aligned_tuple(subchunks, resolved_chunks)
@@ -370,6 +378,16 @@ def _resolve_input_aligned_zarr_layout(
     )
     _validate_subchunks_divide_write_shape(resolved_subchunks, resolved_chunks)
     return resolved_chunks, resolved_subchunks
+
+
+def _aligned_chunk_axes_span_array(
+    shape: ChunkShape,
+    aligned_chunks: tuple[tuple[int, ...], ...],
+) -> tuple[bool, ...]:
+    return tuple(
+        len(axis_chunks) == 1 and int(axis_chunks[0]) == axis_size
+        for axis_size, axis_chunks in zip(shape, aligned_chunks, strict=True)
+    )
 
 
 def _regular_aligned_chunk_shape(
@@ -417,6 +435,46 @@ def _normalize_input_aligned_tuple(
     return resolved
 
 
+def _input_aligned_chunk_shape(
+    *,
+    shape: ChunkShape,
+    aligned_chunk_shape: ChunkShape,
+    axis_spans_array: tuple[bool, ...],
+    subchunks: ChunkSpec,
+) -> ChunkShape:
+    subchunk_shape = _input_aligned_chunk_expansion_subchunk_shape(shape, subchunks)
+    auto_chunk_edge = _input_aligned_auto_chunk_edge(shape)
+    return tuple(
+        _round_up_to_multiple(axis_size, subchunk_size)
+        if axis_spans and axis_size >= auto_chunk_edge
+        else aligned_size
+        for axis_size, aligned_size, axis_spans, subchunk_size in zip(
+            shape, aligned_chunk_shape, axis_spans_array, subchunk_shape, strict=True
+        )
+    )
+
+
+def _input_aligned_auto_chunk_edge(shape: ChunkShape) -> int:
+    is_2d = len(shape) == 3 and shape[0] == 1
+    dimensions = 2 if is_2d else len(shape)
+    return _power_of_two_edge(_DEFAULT_CHUNK_ELEMENTS, dimensions)
+
+
+def _input_aligned_chunk_expansion_subchunk_shape(
+    shape: ChunkShape,
+    subchunks: ChunkSpec,
+) -> ChunkShape:
+    if subchunks == "auto":
+        subchunks = _DEFAULT_SUBCHUNK_ELEMENTS
+    if isinstance(subchunks, int):
+        return _auto_shape(shape, subchunks)
+    assert isinstance(subchunks, tuple)
+    return tuple(
+        axis_size if size == 0 else size
+        for axis_size, size in zip(shape, subchunks, strict=True)
+    )
+
+
 def _input_aligned_subchunk_shape(
     shape: ChunkShape,
     write_shape: ChunkShape,
@@ -445,8 +503,34 @@ def _largest_divisor_at_most(value: int, limit: int) -> int:
 def _validate_aligned_write_shape(
     aligned_chunk_shape: ChunkShape,
     write_shape: ChunkShape,
+    *,
+    axis_spans_array: tuple[bool, ...] | None = None,
 ) -> None:
-    _validate_subchunks_divide_write_shape(write_shape, aligned_chunk_shape)
+    if axis_spans_array is None:
+        axis_spans_array = (False,) * len(aligned_chunk_shape)
+
+    if len(write_shape) != len(aligned_chunk_shape):
+        raise ValueError(
+            "write shape must have the same dimensions as aligned chunks. "
+            f"Got {write_shape} and {aligned_chunk_shape}."
+        )
+    for axis, (write_size, aligned_size, axis_spans) in enumerate(
+        zip(write_shape, aligned_chunk_shape, axis_spans_array, strict=True)
+    ):
+        if write_size <= 0:
+            raise ValueError(f"write shape sizes must be positive. Got {write_shape}.")
+        if axis_spans:
+            if write_size < aligned_size:
+                raise ValueError(
+                    "input_aligned_chunks requires expanded span axes to cover the "
+                    f"aligned chunk. Axis {axis}: {write_size} is smaller than {aligned_size}."
+                )
+            continue
+        if aligned_size % write_size != 0:
+            raise ValueError(
+                "input_aligned_chunks requires write shape to evenly divide the "
+                f"aligned chunk shape. Axis {axis}: {write_size} does not divide {aligned_size}."
+            )
 
 
 def _validate_subchunks_divide_write_shape(

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -1,3 +1,4 @@
+import h5netcdf.legacyapi as nc4
 import numpy as np
 import pytest
 
@@ -51,3 +52,47 @@ def test_read_netcdf_multi():
     for i in range(num_chunks_z):
         chunk = array[i * chunk_z : min((i + 1) * chunk_z, shape_z), ...]
         assert (chunk == i).all()
+
+
+def _write_chunked_netcdf_block(path, data):
+    with nc4.Dataset(path, "w", format="NETCDF4") as ncfile:
+        ncfile.createDimension("tomo_zdim", data.shape[0])
+        ncfile.createDimension("tomo_ydim", data.shape[1])
+        ncfile.createDimension("tomo_xdim", data.shape[2])
+        ncfile.setncattr("voxel_size_xyz", np.array([1.0, 1.0, 1.0], dtype=np.float32))
+        ncfile.setncattr("voxel_unit", np.bytes_(b"mm"))
+        data_var = ncfile.createVariable(
+            "tomo",
+            "u2",
+            ("tomo_zdim", "tomo_ydim", "tomo_xdim"),
+            chunksizes=(2, 4, 5),
+        )
+        data_var[:] = data
+
+
+def test_read_netcdf_respects_internal_chunks_by_default(tmp_path):
+    path = tmp_path / "tomo_chunked.nc"
+    data = np.arange(6 * 8 * 10, dtype=np.uint16).reshape(6, 8, 10)
+    _write_chunked_netcdf_block(path, data)
+
+    dataset = anu_ctlab_io.Dataset.from_path(path, parse_history=False)
+
+    assert dataset.data.chunks == ((2, 2, 2), (4, 4), (5, 5))
+    assert (dataset.data == data).all()
+
+
+def test_read_netcdf_can_treat_each_block_as_one_chunk(tmp_path):
+    path = tmp_path / "tomo_chunked_nc"
+    path.mkdir()
+    block0 = np.zeros((4, 8, 10), dtype=np.uint16)
+    block1 = np.ones((4, 8, 10), dtype=np.uint16)
+    _write_chunked_netcdf_block(path / "block00000000.nc", block0)
+    _write_chunked_netcdf_block(path / "block00000001.nc", block1)
+
+    dataset = anu_ctlab_io.Dataset.from_path(
+        path, parse_history=False, ignore_block_chunks=True
+    )
+
+    assert dataset.data.chunks == ((4, 4), (8,), (10,))
+    assert (dataset.data[:4] == 0).all()
+    assert (dataset.data[4:] == 1).all()

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -1,8 +1,9 @@
-import h5netcdf.legacyapi as nc4
 import numpy as np
 import pytest
 
 try:
+    import h5netcdf.legacyapi as nc4
+
     import anu_ctlab_io.netcdf
 
     _HAS_NETCDF = True

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -836,6 +836,30 @@ def test_integer_shards_support_zero_chunk_sentinels():
     assert shards == (32, 40, 50)
 
 
+def test_input_aligned_integer_chunk_target_uses_dask_chunk_divisors():
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(40, 50, 60),
+        chunks=32**3,
+        shards="auto",
+        aligned_chunks=((20, 20), (50,), (60,)),
+    )
+
+    assert chunks == (20, 25, 30)
+    assert shards == (20, 50, 60)
+
+
+def test_input_aligned_integer_shard_target_allows_multiple_shards_per_dask_chunk():
+    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(32, 32, 32),
+        chunks=4**3,
+        shards=8**3,
+        aligned_chunks=((16, 16), (16, 16), (16, 16)),
+    )
+
+    assert chunks == (4, 4, 4)
+    assert shards == (8, 8, 8)
+
+
 @pytest.mark.parametrize("elements", [0, -1, True])
 def test_invalid_element_targets_raise(elements):
     with pytest.raises(ValueError, match="elements must be a positive integer"):
@@ -934,6 +958,135 @@ def test_write_with_auto_chunks_and_shards(_make_dataset):
 
         loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_input_aligned_chunks_match_dask_chunks_for_sharded_write(_make_dataset):
+    """Input-aligned sharded writes use dask chunks as shards and divisor chunks."""
+    import zarr
+
+    shape = (40, 50, 60)
+    dataset, data = _make_dataset(shape, chunks=(20, 50, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "input_aligned_sharded.zarr"
+
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+            input_aligned_chunks=True,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.shards == (20, 50, 60)
+        assert array.chunks == (20, 25, 30)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_input_aligned_chunks_match_dask_chunks_for_unsharded_write(_make_dataset):
+    """Input-aligned unsharded writes use dask chunks as Zarr chunks."""
+    import zarr
+
+    shape = (40, 50, 60)
+    dataset, data = _make_dataset(shape, chunks=(20, 50, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "input_aligned_unsharded.zarr"
+
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+            shards=None,
+            input_aligned_chunks=True,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.shards is None
+        assert array.chunks == (20, 50, 60)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_input_aligned_chunks_allow_array_edge_remainders(_make_dataset):
+    """Final dask chunks may be smaller at the array edge."""
+    import zarr
+
+    shape = (45, 55, 65)
+    dataset, data = _make_dataset(shape, chunks=(20, 50, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "input_aligned_edges.zarr"
+
+        anu_ctlab_io.zarr.dataset_to_zarr(
+            dataset,
+            output_path,
+            ome_zarr_version=None,
+            input_aligned_chunks=True,
+        )
+
+        array = zarr.open_array(output_path, mode="r")
+        assert array.shards == (20, 50, 60)
+        assert array.chunks == (20, 25, 30)
+
+        loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
+        assert np.array_equal(loaded_dataset.data.compute(), data.compute())
+
+
+def test_input_aligned_chunks_reject_irregular_internal_dask_chunks():
+    """Only the final chunk on each axis may be a smaller remainder."""
+    data = da.zeros((50, 50, 60), chunks=((20, 10, 20), (50,), (60,)))
+    dataset = anu_ctlab_io.Dataset(
+        data,
+        dimension_names=("z", "y", "x"),
+        voxel_unit=anu_ctlab_io.VoxelUnit.MM,
+        voxel_size=(1.0, 1.0, 1.0),
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="regular aligned chunks"):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                Path(tmpdir) / "irregular.zarr",
+                ome_zarr_version=None,
+                input_aligned_chunks=True,
+            )
+
+
+def test_input_aligned_chunks_validates_explicit_tuple_layout(_make_dataset):
+    """Explicit tuple layouts must be compatible with the dask chunk grid."""
+    dataset, _ = _make_dataset((40, 50, 60), chunks=(20, 50, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="evenly divide"):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                Path(tmpdir) / "misaligned.zarr",
+                ome_zarr_version=None,
+                chunks=(7, 25, 30),
+                shards=(20, 50, 60),
+                input_aligned_chunks=True,
+            )
+
+
+def test_input_aligned_chunks_skips_writer_rechunk(_make_dataset):
+    """Validated input-aligned writes do not rechunk before storing."""
+    from unittest.mock import patch
+
+    dataset, _ = _make_dataset((40, 50, 60), chunks=(20, 50, 60))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.object(da.Array, "rechunk", side_effect=AssertionError):
+            anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                Path(tmpdir) / "no_rechunk.zarr",
+                ome_zarr_version=None,
+                slice_thumbnails=False,
+                input_aligned_chunks=True,
+            )
 
 
 def test_size_parameters_and_explicit_shapes(_make_dataset):

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -862,6 +862,33 @@ def test_input_aligned_integer_shard_target_allows_multiple_shards_per_dask_chun
     assert subchunks == (4, 4, 4)
 
 
+@pytest.mark.parametrize(
+    ("shape", "aligned_chunks", "chunks", "subchunks"),
+    [
+        # One chunk on XY, subchunk doesn't evenly divide. Zarr chunk expands to accommodate.
+        ((32, 2914, 2914), ((32,), (2914,), (2914,)), (32, 2944, 2944), (32, 32, 32)),
+        ((32, 997, 997), ((32,), (997,), (997,)), (32, 1024, 1024), (32, 32, 32)),
+        # Multiple chunks on XY with prime number sizes. Mango cannot create this, but this checks rechunking still doesn't occur even though the subchunk size is highly suboptimal
+        (
+            (32, 997 * 2, 997 * 2),
+            ((32,), (997, 997), (997, 997)),
+            (32, 997, 997),
+            (32, 1, 1),
+        ),
+    ],
+)
+def test_resolve_zarr_layout_edge_and_prime(shape, aligned_chunks, chunks, subchunks):
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+        shape=(68, 2914, 2914),
+        chunks="auto",
+        subchunks="auto",
+        aligned_chunks=aligned_chunks,
+    )
+
+    assert chunks == chunks
+    assert subchunks == subchunks
+
+
 def test_normalize_explicit_shapes_uses_internal_chunk_subchunk_order():
     chunks, subchunks = anu_ctlab_io.zarr._writer._normalize_explicit_shapes(
         shape=(60, 40, 50),
@@ -1100,6 +1127,39 @@ def test_input_aligned_chunks_skips_writer_rechunk(_make_dataset):
                 slice_thumbnails=False,
                 input_aligned_chunks=True,
             )
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks"),
+    [
+        ((68, 2914, 2914), ((32,) * 2 + (4,), (2914,), (2914,))),
+        ((68, 997, 997), ((32,) * 2 + (4,), (997,), (997,))),
+        ((68, 997 * 2, 997 * 2), ((32,) * 2 + (4,), (997, 997), (997, 997))),
+    ],
+)
+def test_input_aligned_large_array_writes_skip_rechunk(shape, chunks):
+    """Large input-aligned writes build the store graph without rechunking."""
+    from unittest.mock import patch
+
+    data = da.zeros(shape, chunks=chunks, dtype=np.uint16)
+    dataset = anu_ctlab_io.Dataset(
+        data,
+        dimension_names=("z", "y", "x"),
+        voxel_unit=anu_ctlab_io.VoxelUnit.MM,
+        voxel_size=(1.0, 1.0, 1.0),
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.object(da.Array, "rechunk", side_effect=AssertionError):
+            result = anu_ctlab_io.zarr.dataset_to_zarr(
+                dataset,
+                Path(tmpdir) / "no_large_rechunk.zarr",
+                ome_zarr_version=None,
+                input_aligned_chunks=True,
+                compute=False,
+            )
+
+    assert result is not None
 
 
 def test_size_parameters_and_explicit_shapes(_make_dataset):

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -718,18 +718,18 @@ def test_no_false_warning_with_remainder_chunks(_make_dataset):
 
 
 @pytest.mark.parametrize(
-    ("shape", "chunks", "shards", "expected_chunks", "expected_shards"),
+    ("shape", "chunks", "shards", "expected_chunks", "expected_subchunks"),
     [
-        ((40, 65, 97), "auto", "auto", (32, 32, 32), (64, 96, 128)),
-        ((1, 600, 700), "auto", "auto", (1, 256, 256), (1, 768, 768)),
-        ((21, 200, 300), "auto", "auto", (21, 32, 32), (21, 224, 320)),
-        ((60, 40, 50), (10, 0, 25), (30, 0, 0), (10, 40, 25), (30, 40, 50)),
-        ((1000, 512, 512), "auto", "auto", (32, 32, 32), (512, 512, 512)),
-        ((10, 20, 30), (5, 20, 30), (10, 20, 30), (5, 20, 30), (10, 20, 30)),
-        ((40, 65, 97), "auto", None, (32, 32, 32), None),
+        ((40, 65, 97), "auto", "auto", (64, 96, 128), (32, 32, 32)),
+        ((1, 600, 700), "auto", "auto", (1, 768, 768), (1, 256, 256)),
+        ((21, 200, 300), "auto", "auto", (21, 224, 320), (21, 32, 32)),
+        ((60, 40, 50), (10, 0, 25), (30, 0, 0), (30, 40, 50), (10, 40, 25)),
+        ((1000, 512, 512), "auto", "auto", (512, 512, 512), (32, 32, 32)),
+        ((10, 20, 30), (5, 20, 30), (10, 20, 30), (10, 20, 30), (5, 20, 30)),
+        ((40, 65, 97), "auto", None, (40, 65, 97), None),
         ((10, 20, 30), "auto", "auto", (10, 20, 30), (10, 20, 30)),
         ((10, 20, 30), (5, 0, 0), None, (5, 20, 30), None),
-        ((40, 65, 97), (32, 32, 32), (32, 0, 0), (32, 32, 32), (32, 96, 128)),
+        ((40, 65, 97), (32, 32, 32), (32, 0, 0), (32, 96, 128), (32, 32, 32)),
     ],
 )
 def test_resolve_zarr_layout(
@@ -737,16 +737,18 @@ def test_resolve_zarr_layout(
     chunks,
     shards,
     expected_chunks,
-    expected_shards,
+    expected_subchunks,
 ):
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
-        shape=shape,
-        chunks=chunks,
-        shards=shards,
+    resolved_chunks, resolved_subchunks = (
+        anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+            shape=shape,
+            chunks=shards if shards is not None else chunks,
+            subchunks=chunks if shards is not None else None,
+        )
     )
 
-    assert chunks == expected_chunks
-    assert shards == expected_shards
+    assert resolved_chunks == expected_chunks
+    assert resolved_subchunks == expected_subchunks
 
 
 @pytest.mark.parametrize(
@@ -761,7 +763,7 @@ def test_integer_chunks_are_element_based(elements, expected_chunks):
     chunks, _ = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(1024, 1024, 1024),
         chunks=elements,
-        shards=None,
+        subchunks=None,
     )
 
     assert chunks == expected_chunks
@@ -779,85 +781,96 @@ def test_integer_chunks_are_element_based_for_2d(elements, expected_chunks):
     chunks, _ = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(1, 1024, 1024),
         chunks=elements,
-        shards=None,
+        subchunks=None,
     )
 
     assert chunks == expected_chunks
 
 
 @pytest.mark.parametrize(
-    ("shape", "expected_chunks", "expected_shards"),
+    ("shape", "expected_chunks", "expected_subchunks"),
     [
-        ((1024, 1024, 1024), (32, 32, 32), (512, 512, 512)),
-        ((1, 65536, 65536), (1, 256, 256), (1, 8192, 8192)),
+        ((1024, 1024, 1024), (512, 512, 512), (32, 32, 32)),
+        ((1, 65536, 65536), (1, 8192, 8192), (1, 256, 256)),
     ],
 )
-def test_auto_uses_default_element_targets(shape, expected_chunks, expected_shards):
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+def test_auto_uses_default_element_targets(shape, expected_chunks, expected_subchunks):
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=shape,
         chunks="auto",
-        shards="auto",
+        subchunks="auto",
     )
 
     assert chunks == expected_chunks
-    assert shards == expected_shards
+    assert subchunks == expected_subchunks
 
 
 def test_integer_shards_are_chunk_multiples():
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(100, 100, 100),
-        chunks=(10, 20, 25),
-        shards=32**3,
+        chunks=32**3,
+        subchunks=(10, 20, 25),
     )
 
-    assert chunks == (10, 20, 25)
-    assert shards == (40, 40, 50)
+    assert chunks == (40, 40, 50)
+    assert subchunks == (10, 20, 25)
 
 
 def test_integer_shards_are_chunk_multiples_for_2d():
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(1, 100, 100),
-        chunks=(1, 20, 25),
-        shards=32**2,
+        chunks=32**2,
+        subchunks=(1, 20, 25),
     )
 
-    assert chunks == (1, 20, 25)
-    assert shards == (1, 40, 50)
+    assert chunks == (1, 40, 50)
+    assert subchunks == (1, 20, 25)
 
 
 def test_integer_shards_support_zero_chunk_sentinels():
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(100, 100, 100),
-        chunks=(0, 20, 25),
-        shards=32**3,
+        chunks=32**3,
+        subchunks=(0, 20, 25),
     )
 
-    assert chunks == (32, 20, 25)
-    assert shards == (32, 40, 50)
+    assert chunks == (32, 40, 50)
+    assert subchunks == (32, 20, 25)
 
 
 def test_input_aligned_integer_chunk_target_uses_dask_chunk_divisors():
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(40, 50, 60),
-        chunks=32**3,
-        shards="auto",
+        chunks="auto",
+        subchunks=32**3,
         aligned_chunks=((20, 20), (50,), (60,)),
     )
 
-    assert chunks == (20, 25, 30)
-    assert shards == (20, 50, 60)
+    assert chunks == (20, 50, 60)
+    assert subchunks == (20, 25, 30)
 
 
 def test_input_aligned_integer_shard_target_allows_multiple_shards_per_dask_chunk():
-    chunks, shards = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
+    chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
         shape=(32, 32, 32),
-        chunks=4**3,
-        shards=8**3,
+        chunks=8**3,
+        subchunks=4**3,
         aligned_chunks=((16, 16), (16, 16), (16, 16)),
     )
 
-    assert chunks == (4, 4, 4)
-    assert shards == (8, 8, 8)
+    assert chunks == (8, 8, 8)
+    assert subchunks == (4, 4, 4)
+
+
+def test_normalize_explicit_shapes_uses_internal_chunk_subchunk_order():
+    chunks, subchunks = anu_ctlab_io.zarr._writer._normalize_explicit_shapes(
+        shape=(60, 40, 50),
+        chunks=(30, 0, 0),
+        subchunks=(10, 0, 25),
+    )
+
+    assert chunks == (30, 40, 50)
+    assert subchunks == (10, 40, 25)
 
 
 @pytest.mark.parametrize("elements", [0, -1, True])
@@ -866,7 +879,7 @@ def test_invalid_element_targets_raise(elements):
         anu_ctlab_io.zarr._writer._resolve_zarr_layout(
             shape=(100, 100, 100),
             chunks=elements,
-            shards=None,
+            subchunks=None,
         )
 
 
@@ -929,7 +942,7 @@ def test_write_with_auto_chunks(_make_dataset):
 
         array = zarr.open_array(output_path, mode="r")
         assert array.shards is None
-        assert array.chunks == (10, 20, 32)
+        assert array.chunks == (10, 20, 60)
 
         loaded_dataset = anu_ctlab_io.Dataset.from_path(output_path)
         assert np.array_equal(loaded_dataset.data.compute(), data.compute())

--- a/tests/test_zarr_write.py
+++ b/tests/test_zarr_write.py
@@ -863,7 +863,7 @@ def test_input_aligned_integer_shard_target_allows_multiple_shards_per_dask_chun
 
 
 @pytest.mark.parametrize(
-    ("shape", "aligned_chunks", "chunks", "subchunks"),
+    ("shape", "aligned_chunks", "expected_chunks", "expected_subchunks"),
     [
         # One chunk on XY, subchunk doesn't evenly divide. Zarr chunk expands to accommodate.
         ((32, 2914, 2914), ((32,), (2914,), (2914,)), (32, 2944, 2944), (32, 32, 32)),
@@ -877,16 +877,18 @@ def test_input_aligned_integer_shard_target_allows_multiple_shards_per_dask_chun
         ),
     ],
 )
-def test_resolve_zarr_layout_edge_and_prime(shape, aligned_chunks, chunks, subchunks):
+def test_resolve_zarr_layout_edge_and_prime(
+    shape, aligned_chunks, expected_chunks, expected_subchunks
+):
     chunks, subchunks = anu_ctlab_io.zarr._writer._resolve_zarr_layout(
-        shape=(68, 2914, 2914),
+        shape=shape,
         chunks="auto",
         subchunks="auto",
         aligned_chunks=aligned_chunks,
     )
 
-    assert chunks == chunks
-    assert subchunks == subchunks
+    assert chunks == expected_chunks
+    assert subchunks == expected_subchunks
 
 
 def test_normalize_explicit_shapes_uses_internal_chunk_subchunk_order():

--- a/uv.lock
+++ b/uv.lock
@@ -135,6 +135,7 @@ source = { editable = "cli" }
 dependencies = [
     { name = "anu-ctlab-io", extra = ["all"] },
     { name = "dask", extra = ["distributed"] },
+    { name = "graphviz" },
     { name = "typer" },
 ]
 
@@ -148,6 +149,7 @@ requires-dist = [
     { name = "anu-ctlab-io", extras = ["all"], editable = "." },
     { name = "dask", extras = ["distributed"], specifier = ">=2025.2.0" },
     { name = "dask-mpi", marker = "extra == 'mpi'", specifier = ">=2026.3.0" },
+    { name = "graphviz", specifier = ">=0.21" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
 provides-extras = ["mpi"]
@@ -469,6 +471,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
     { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
     { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Used by default in the CLI when converting to Zarr.

Add `input_aligned_chunks` parameter to `dataset_to_zarr` and  `ignore_block_chunks` to NetCDF reader, both defaulting to false. Used by default in the CLI on the NetCDF->Zarr path.

Ignoring block chunks is necessary because sometimes the internal chunking in our NetCDF datasets be irregularly gridded between blocks. With `input_aligned_chunks`, the Zarr output will just match the NetCDF blocking (but will use subchunking).

- add `lint` recipe
- Use chunks/subchunks internally in `zarr/_writer.py`. Makes the logic much clearer to me (and LLMs?)

> [!NOTE]
> This is all severely overcomplicated by the fact that we are not utilising `rectilinear` grids yet (waiting on ecosystem support) and that the sharding codec requires subchunks to evenly divide the chunk shape. I am working on lifting that restriction in the spec. Also, I would ultimately prefer to go a virtualisation path in the future for NetCDF -> Zarr so that we can avoid rewriting any chunk data.